### PR TITLE
Update ed25519 FFI sample to resolve memory issues

### DIFF
--- a/libursa/include/ursa_crypto_ed25519.h
+++ b/libursa/include/ursa_crypto_ed25519.h
@@ -5,6 +5,8 @@
 extern "C" {
 #endif
 
+extern void ursa_ed25519_bytebuffer_free(struct ByteBuffer buffer);
+
 extern int32_t ursa_ed25519_get_public_key_size(void);
 extern int32_t ursa_ed25519_get_private_key_size(void);
 extern int32_t ursa_ed25519_get_signature_size(void);
@@ -36,4 +38,3 @@ extern int32_t ursa_ed25519_verify(const uint8_t* const message, uint64_t messag
 #endif
 
 #endif
-

--- a/libursa/src/ffi/signatures/ed25519.rs
+++ b/libursa/src/ffi/signatures/ed25519.rs
@@ -33,6 +33,11 @@
 //         return 1;
 //     }
 //
+//     ursa_ed25519_bytebuffer_free(*public_key);
+//     ursa_ed25519_bytebuffer_free(*private_key);
+//
+//     ursa_ed25519_bytebuffer_free(*seed);
+//
 //     free(seed);
 //
 //     printf("Success from seed!\n");
@@ -78,6 +83,11 @@
 //         return 1;
 //     }
 //     printf("Verified!\n");
+//
+//     ursa_ed25519_bytebuffer_free(*public_key);
+//     ursa_ed25519_bytebuffer_free(*private_key);
+//     ursa_ed25519_bytebuffer_free(*message);
+//     ursa_ed25519_bytebuffer_free(*signature);
 //
 //     free(public_key);
 //     free(private_key);
@@ -128,7 +138,8 @@ pub extern "C" fn ursa_ed25519_get_signature_size() -> i32 {
 }
 
 /// Create a new keypair.
-/// Caller will need to free the memory for on `public_key` and `private_key`
+/// Caller will need to call `ursa_ed25519_bytebuffer_free` on `public_key` and `private_key`
+/// to free the memory.
 #[no_mangle]
 pub extern "C" fn ursa_ed25519_keypair_new(
     public_key: &mut ByteBuffer,
@@ -139,7 +150,8 @@ pub extern "C" fn ursa_ed25519_keypair_new(
 }
 
 /// Create a new keypair from a seed.
-/// Caller will need to free the memory for on `public_key` and `private_key`
+/// Caller will need to call `ursa_ed25519_bytebuffer_free` on `public_key` and `private_key`
+/// to free the memory.
 #[no_mangle]
 pub extern "C" fn ursa_ed25519_keypair_from_seed(
     seed: *const u8,
@@ -160,8 +172,9 @@ pub extern "C" fn ursa_ed25519_keypair_from_seed(
     )
 }
 
-/// Create a new keypair from a seed.
-/// Caller will need to free the memory for on `public_key` and `private_key`
+/// Get a public key from a private key.
+/// Caller will need to call `ursa_ed25519_bytebuffer_free` on `public_key` and `private_key`
+/// to free the memory.
 #[no_mangle]
 pub extern "C" fn ursa_ed25519_get_public_key(
     private_key: *const u8,
@@ -184,7 +197,8 @@ pub extern "C" fn ursa_ed25519_get_public_key(
 }
 
 /// Sign a message
-/// Caller will need to free the memory for on `signature`
+/// Caller will need to call `ursa_ed25519_bytebuffer_free` on `signature`
+/// to free the memory.
 #[no_mangle]
 pub extern "C" fn ursa_ed25519_sign(
     message: *const u8,


### PR DESCRIPTION
Hello,

I believe the sample `C` code (provided in `libursa/src/ffi/signatures/ed25519.rs`) for using ed25519 signing leaks memory.

Valgrind reports 273 bytes leaked (Output below).

```
==17242== HEAP SUMMARY:
==17242==     in use at exit: 273 bytes in 7 blocks
==17242==   total heap usage: 22 allocs, 15 frees, 74,395 bytes allocated
==17242== 
==17242== 7 bytes in 1 blocks are definitely lost in loss record 1 of 7
==17242==    at 0x483877F: malloc (vg_replace_malloc.c:299)
==17242==    by 0x1093AE: main (in /mnt/external/Hyperledger/ursa-cpp/build/ursacpp)
==17242== 
==17242== 10 bytes in 1 blocks are definitely lost in loss record 2 of 7
==17242==    at 0x483877F: malloc (vg_replace_malloc.c:299)
==17242==    by 0x10921D: main (in /mnt/external/Hyperledger/ursa-cpp/build/ursacpp)
==17242== 
==17242== 32 bytes in 1 blocks are definitely lost in loss record 3 of 7
==17242==    at 0x483877F: malloc (vg_replace_malloc.c:299)
==17242==    by 0x4949FE0: ursa::ffi::signatures::ed25519::ursa_ed25519_keypair_gen (in /mnt/external/Hyperledger/ursa-cpp/build/libursa/lib/libursa.so)
==17242==    by 0x4948960: ursa_ed25519_keypair_from_seed (in /mnt/external/Hyperledger/ursa-cpp/build/libursa/lib/libursa.so)
==17242==    by 0x109304: main (in /mnt/external/Hyperledger/ursa-cpp/build/ursacpp)
==17242== 
==17242== 32 bytes in 1 blocks are definitely lost in loss record 4 of 7
==17242==    at 0x483877F: malloc (vg_replace_malloc.c:299)
==17242==    by 0x4949FE0: ursa::ffi::signatures::ed25519::ursa_ed25519_keypair_gen (in /mnt/external/Hyperledger/ursa-cpp/build/libursa/lib/libursa.so)
==17242==    by 0x49488AF: ursa_ed25519_keypair_new (in /mnt/external/Hyperledger/ursa-cpp/build/libursa/lib/libursa.so)
==17242==    by 0x109352: main (in /mnt/external/Hyperledger/ursa-cpp/build/ursacpp)
==17242== 
==17242== 64 bytes in 1 blocks are definitely lost in loss record 5 of 7
==17242==    at 0x483877F: malloc (vg_replace_malloc.c:299)
==17242==    by 0x494A092: ursa::ffi::signatures::ed25519::ursa_ed25519_keypair_gen (in /mnt/external/Hyperledger/ursa-cpp/build/libursa/lib/libursa.so)
==17242==    by 0x4948960: ursa_ed25519_keypair_from_seed (in /mnt/external/Hyperledger/ursa-cpp/build/libursa/lib/libursa.so)
==17242==    by 0x109304: main (in /mnt/external/Hyperledger/ursa-cpp/build/ursacpp)
==17242== 
==17242== 64 bytes in 1 blocks are definitely lost in loss record 6 of 7
==17242==    at 0x483877F: malloc (vg_replace_malloc.c:299)
==17242==    by 0x494A092: ursa::ffi::signatures::ed25519::ursa_ed25519_keypair_gen (in /mnt/external/Hyperledger/ursa-cpp/build/libursa/lib/libursa.so)
==17242==    by 0x49488AF: ursa_ed25519_keypair_new (in /mnt/external/Hyperledger/ursa-cpp/build/libursa/lib/libursa.so)
==17242==    by 0x109352: main (in /mnt/external/Hyperledger/ursa-cpp/build/ursacpp)
==17242== 
==17242== 64 bytes in 1 blocks are definitely lost in loss record 7 of 7
==17242==    at 0x483877F: malloc (vg_replace_malloc.c:299)
==17242==    by 0x48D8EFF: <ursa::signatures::ed25519::Ed25519Sha512 as ursa::signatures::SignatureScheme>::sign (in /mnt/external/Hyperledger/ursa-cpp/build/libursa/lib/libursa.so)
==17242==    by 0x4948E53: ursa_ed25519_sign (in /mnt/external/Hyperledger/ursa-cpp/build/libursa/lib/libursa.so)
==17242==    by 0x10951D: main (in /mnt/external/Hyperledger/ursa-cpp/build/ursacpp)
==17242== 
==17242== LEAK SUMMARY:
==17242==    definitely lost: 273 bytes in 7 blocks
==17242==    indirectly lost: 0 bytes in 0 blocks
==17242==      possibly lost: 0 bytes in 0 blocks
==17242==    still reachable: 0 bytes in 0 blocks
==17242==         suppressed: 0 bytes in 0 blocks
==17242== 
==17242== For counts of detected and suppressed errors, rerun with: -v
==17242== ERROR SUMMARY: 7 errors from 7 contexts (suppressed: 0 from 0)
```

I think this is because the ByteBuffer struct has a member (`*data`) that is itself a pointer. Calling something like `free(public_key)` will not free the data pointer in the struct. 

I was able to resolve these memory errors by adding the `ursa_ed25519_bytebuffer_free` function to the ursa header file, calling it on the ByteBuffer itself, and then freeing the pointer to the ByteBuffer. 