### PR TITLE
Update documentation and docker files

### DIFF
--- a/docker/centos/Dockerfile
+++ b/docker/centos/Dockerfile
@@ -9,12 +9,12 @@ ENV LD_LIBRARY_PATH /usr/local/lib
 WORKDIR /root
 
 RUN yum -y update && yum -y install sudo make autoconf libtool curl python3 pkg-config openssl-devel 2>&1 > /dev/null \
-    && curl -fsSL https://download.libsodium.org/libsodium/releases/libsodium-1.0.16.tar.gz | tar -xz \
-    && cd libsodium-1.0.16 \ 
+    && curl -fsSL https://github.com/jedisct1/libsodium/archive/1.0.18.tar.gz | tar -xz \
+    && cd libsodium-1.0.18 \
     && ./autogen.sh \
     && ./configure --disable-dependency-tracking \
     && make \
     && make install \
     && cd .. \
-    && rm -rf libsodium-1.0.16 \
+    && rm -rf libsodium-1.0.18 \
     && curl https://sh.rustup.rs -sSf | sh -s -- -y

--- a/docker/fedora/Dockerfile
+++ b/docker/fedora/Dockerfile
@@ -9,12 +9,12 @@ ENV LD_LIBRARY_PATH /usr/local/lib
 WORKDIR /root
 
 RUN yum -y update && yum -y install sudo make autoconf libtool curl python3 pkg-config openssl-devel 2>&1 > /dev/null \
-    && curl -fsSL https://download.libsodium.org/libsodium/releases/libsodium-1.0.16.tar.gz | tar -xz \
-    && cd libsodium-1.0.16 \ 
+    && curl -fsSL https://github.com/jedisct1/libsodium/archive/1.0.18.tar.gz | tar -xz \
+    && cd libsodium-1.0.18 \
     && ./autogen.sh \
     && ./configure --disable-dependency-tracking \
     && make \
     && make install \
     && cd .. \
-    && rm -rf libsodium-1.0.16 \
+    && rm -rf libsodium-1.0.18 \
     && curl https://sh.rustup.rs -sSf | sh -s -- -y

--- a/docker/suse/Dockerfile
+++ b/docker/suse/Dockerfile
@@ -9,12 +9,12 @@ ENV LD_LIBRARY_PATH /usr/local/lib
 WORKDIR /root
 
 RUN zypper --non-interactive update && zypper --non-interactive install sudo make gcc autoconf libtool curl python3 pkg-config openssl-devel 2>&1 > /dev/null \
-    && curl -fsSL https://download.libsodium.org/libsodium/releases/libsodium-1.0.16.tar.gz | tar -xz \
-    && cd libsodium-1.0.16 \ 
+    && curl -fsSL https://github.com/jedisct1/libsodium/archive/1.0.18.tar.gz | tar -xz \
+    && cd libsodium-1.0.18 \
     && ./autogen.sh \
     && ./configure \
     && make \
     && make install \
     && cd .. \
-    && rm -rf libsodium-1.0.16 \
+    && rm -rf libsodium-1.0.18 \
     && curl https://sh.rustup.rs -sSf | sh -s -- -y

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -13,11 +13,11 @@ RUN apt-get update 2>&1 > /dev/null \
     && cd /usr/lib/x86_64-linux-gnu \
     && ln -s libssl.so.1.0.0 libssl.so.10 \
     && ln -s libcrypto.so.1.0.0 libcrypto.so.10 \
-    && curl -fsSL https://download.libsodium.org/libsodium/releases/libsodium-1.0.16.tar.gz | tar -xz \
-    && cd libsodium-1.0.16 \ 
+    && curl -fsSL https://github.com/jedisct1/libsodium/archive/1.0.18.tar.gz | tar -xz \
+    && cd libsodium-1.0.18 \
     && ./autogen.sh \
     && ./configure \
     && make install \
     && cd .. \
-    && rm -rf libsodium-1.0.16 \
+    && rm -rf libsodium-1.0.18 \
     && curl https://sh.rustup.rs -sSf | sh -s -- -y

--- a/docs/build-environment.md
+++ b/docs/build-environment.md
@@ -16,7 +16,7 @@ source ~/.cargo/env
 ```
 4. Compile and install libsodium 1.0.18
 ```bash
-curl -fsSL https://github.com/jedisct1/libsodium/releases/download/1.0.18/libsodium-1.0.18.tar.gz | tar -xz
+curl -fsSL https://github.com/jedisct1/libsodium/archive/1.0.18.tar.gz | tar -xz
 cd libsodium-1.0.18
 ./autogen.sh
 ./configure --disable-dependency-tracking
@@ -44,7 +44,7 @@ source ~/.cargo/env
 ```
 4. Compile and install libsodium 1.0.18
 ```bash
-curl -fsSL https://github.com/jedisct1/libsodium/releases/download/1.0.16/libsodium-1.0.18.tar.gz | tar -xz
+curl -fsSL https://github.com/jedisct1/libsodium/archive/1.0.18.tar.gz | tar -xz
 cd libsodium-1.0.18
 ./autogen.sh
 ./configure
@@ -72,7 +72,7 @@ source ~/.cargo/env
 ```
 4. Compile and install libsodium 1.0.18
 ```bash
-curl -fsSL https://github.com/jedisct1/libsodium/releases/download/1.0.18/libsodium-1.0.18.tar.gz | tar -xz
+curl -fsSL https://github.com/jedisct1/libsodium/archive/1.0.18.tar.gz | tar -xz
 cd libsodium-1.0.18
 ./autogen.sh
 ./configure
@@ -112,7 +112,7 @@ source ~/.cargo/env
 ```
 6. Compile and install libsodium 1.0.18
 ```bash
-curl -fsSL https://github.com/jedisct1/libsodium/releases/download/1.0.18/libsodium-1.0.18.tar.gz | tar -xz
+curl -fsSL https://github.com/jedisct1/libsodium/archive/1.0.18.tar.gz | tar -xz
 cd libsodium-1.0.18
 ./autogen.sh
 ./configure --prefix=/usr/local


### PR DESCRIPTION
The libsodium link was moved for 1.0.18 and the docker files were using 1.0.16. This fixes both of those references to use 1.0.18 and the correct link.

Thanks to @burdettadam for finding the discrepancy 