### PR TITLE
Wasm for ursa

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,13 @@ addons:
 matrix:
   include:
     - name: "rustfmt"
+      rust: stable
       before_script:
         - rustup component add rustfmt
       script:
         - cargo fmt --all -- --check
     - name: "cargo clippy"
+      rust: stable
       before_script:
         - rustup component add clippy
       script:
@@ -53,5 +55,12 @@ matrix:
       script:
         - SODIUM_BUILD_STATIC=1 cargo run --release --manifest-path=libursa/Cargo.toml --bin test_ed25519 --features="benchmarked25519"
     - name: "cargo doc"
+      rust: stable
       script:
         - cargo doc --no-deps
+    - name: "cargo wasm"
+      rust: stable
+      before_script:
+        -  curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+      script:
+        - wasm-pack build libursa -- --no-default-features --features=wasm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -82,6 +82,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -465,6 +473,11 @@ version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "gcc"
+version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "generic-array"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -501,6 +514,16 @@ dependencies = [
  "num-traits 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "hex"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "hex"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "hmac"
@@ -786,6 +809,27 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rdrand 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "rand"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -1005,6 +1049,19 @@ dependencies = [
 name = "regex-syntax"
 version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "rust-crypto-wasm"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "base64 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "rustc-demangle"
@@ -1266,6 +1323,7 @@ dependencies = [
  "ffi-support 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "generic-array 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "glass_pumpkin 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "int_traits 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "js-sys 0.3.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1278,6 +1336,7 @@ dependencies = [
  "openssl 0.10.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand_chacha 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rust-crypto-wasm 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "secp256k1 0.15.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.101 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1482,6 +1541,7 @@ dependencies = [
 "checksum autocfg 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 "checksum backtrace 0.3.40 (registry+https://github.com/rust-lang/crates.io-index)" = "924c76597f0d9ca25d762c25a4d369d51267536465dc5064bdf0eb073ed477ea"
 "checksum backtrace-sys 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
+"checksum base64 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "30e93c03064e7590d0466209155251b90c22e37fab1daf2771582598b5827557"
 "checksum bitflags 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 "checksum blake2 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "94cb07b0da6a73955f8fb85d24c466778e70cda767a568229b104f0264089330"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
@@ -1525,10 +1585,13 @@ dependencies = [
 "checksum foreign-types 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 "checksum foreign-types-shared 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+"checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
 "checksum generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
 "checksum generic-array 0.13.2 (registry+https://github.com/rust-lang/crates.io-index)" = "0ed1e761351b56f54eb9dcd0cfaca9fd0daecf93918e1cfc01c8a3d26ee7adcd"
 "checksum getrandom 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "473a1265acc8ff1e808cd0a1af8cee3c2ee5200916058a2ca113c29f2d903571"
 "checksum glass_pumpkin 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3b0e4ad2fc1040c455d7c0eb78e96bd81e7049167f7b0cf1aa7a23023e5d744a"
+"checksum hex 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d6a22814455d41612f41161581c2883c0c6a1c41852729b17d5ed88f01e153aa"
+"checksum hex 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "023b39be39e3a2da62a94feb433e91e8bcd37676fbc8bea371daf52b7a769a3e"
 "checksum hmac 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5dcb5e64cda4c23119ab41ba960d1e170a774c8e4b9d9e6a9bc18aabf5e59695"
 "checksum hmac-drbg 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c6e570451493f10f6581b48cdd530413b63ea9e780f544bfd3bdcaa0d89d1a7b"
 "checksum humantime 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
@@ -1565,6 +1628,8 @@ dependencies = [
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
+"checksum rand 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)" = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
+"checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 "checksum rand 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
 "checksum rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 "checksum rand 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3ae1b169243eaf61759b8475a998f0a385e42042370f3a7dbaf35246eacc8412"
@@ -1589,6 +1654,7 @@ dependencies = [
 "checksum regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dc220bd33bdce8f093101afe22a037b8eb0e5af33592e6a9caafff0d4cb81cbd"
 "checksum regex-automata 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "92b73c2a1770c255c240eaa4ee600df1704a38dc3feaa6e949e7fcd4f8dc09f9"
 "checksum regex-syntax 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "11a7e20d1cce64ef2fed88b66d347f88bd9babb82845b2b858f3edbf59a4f716"
+"checksum rust-crypto-wasm 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "9dcf11edbc9a0effb4a99ddbe909dd26fb2e71459064879218c27b0add1cb6ec"
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"

--- a/libursa/Cargo.toml
+++ b/libursa/Cargo.toml
@@ -51,7 +51,7 @@ bn_openssl = ["openssl", "int_traits"]
 bn_rust = ["num-bigint", "glass_pumpkin", "int_traits", "num-integer", "num-traits"]
 pair_amcl = ["amcl"]
 serialization = ["serde", "serde_json", "serde_derive"]
-wasm = ["wasm-bindgen", "console_error_panic_hook", "portable", "js-sys"]
+wasm = ["wasm-bindgen", "console_error_panic_hook", "pair_amcl", "bn_rust", "serialization", "rustlibsecp256k1", "bls", "blake2/std", "sha2/std", "js-sys", "rust-crypto-wasm"]
 ffi = ["ffi-support"]
 cl = []
 bls = []
@@ -93,6 +93,8 @@ glass_pumpkin = { version = "0.3", optional = true }
 num-integer = { version = "0.1", optional = true }
 num-traits = { version = "0.2", optional = true }
 ffi-support = { version = "0.3.5", optional = true }
+rust-crypto-wasm = { version = "0.3.1", optional = true }
+hex = "0.4"
 
 [dev-dependencies]
 openssl = "0.10"

--- a/libursa/bin/test_ed25519.rs
+++ b/libursa/bin/test_ed25519.rs
@@ -1,8 +1,7 @@
 extern crate libsodium_ffi as ffi;
 extern crate ursa;
 
-use ursa::signatures::ed25519::Ed25519Sha512;
-use ursa::signatures::SignatureScheme;
+use ursa::signatures::prelude::*;
 
 use std::io;
 use std::io::Write;

--- a/libursa/src/ffi/signatures/ed25519.rs
+++ b/libursa/src/ffi/signatures/ed25519.rs
@@ -148,7 +148,7 @@
 use super::super::ByteArray;
 use keys::{KeyGenOption, PrivateKey, PublicKey};
 use signatures::ed25519;
-use signatures::SignatureScheme;
+use signatures::prelude::*;
 
 use ffi_support::{ByteBuffer, ErrorCode, ExternError};
 
@@ -245,7 +245,7 @@ pub extern "C" fn ursa_ed25519_sign(
     signature: &mut ByteBuffer,
     err: &mut ExternError,
 ) -> i32 {
-    let scheme = ed25519::Ed25519Sha512::new();
+    let scheme = Ed25519Sha512::new();
     let sk = PrivateKey(private_key.to_vec());
 
     match scheme.sign(message.to_vec().as_slice(), &sk) {
@@ -274,7 +274,7 @@ pub extern "C" fn ursa_ed25519_verify(
     public_key: &ByteArray,
     err: &mut ExternError,
 ) -> i32 {
-    let scheme = ed25519::Ed25519Sha512::new();
+    let scheme = Ed25519Sha512::new();
     let pk = PublicKey(public_key.to_vec());
 
     match scheme.verify(
@@ -306,7 +306,7 @@ fn ursa_ed25519_keypair_gen(
     private_key: Option<&mut ByteBuffer>,
     err: &mut ExternError,
 ) -> i32 {
-    let scheme = ed25519::Ed25519Sha512::new();
+    let scheme = Ed25519Sha512::new();
     match scheme.keypair(option) {
         Ok((pk, sk)) => {
             *err = ExternError::success();

--- a/libursa/src/lib.rs
+++ b/libursa/src/lib.rs
@@ -27,13 +27,17 @@ extern crate failure;
 extern crate log;
 pub extern crate blake2;
 extern crate generic_array;
+extern crate hex;
 #[cfg(test)]
 extern crate libsodium_ffi;
 extern crate rand;
 extern crate rand_chacha;
-#[cfg(all(feature = "portable", not(feature = "native")))]
+#[cfg(all(any(feature = "portable", feature = "wasm"), not(feature = "native")))]
 extern crate rustlibsecp256k1;
-#[cfg(any(test, all(feature = "native", not(feature = "portable"))))]
+#[cfg(any(
+    test,
+    all(feature = "native", not(any(feature = "portable", feature = "wasm")))
+))]
 extern crate secp256k1 as libsecp256k1;
 pub extern crate sha2;
 pub extern crate sha3;
@@ -75,6 +79,9 @@ extern crate ffi_support;
 
 extern crate time;
 
+#[cfg(feature = "wasm")]
+extern crate crypto;
+#[cfg(not(feature = "wasm"))]
 extern crate ed25519_dalek;
 
 #[cfg(feature = "cl")]

--- a/libursa/src/signatures/ed25519/ed25519.rs
+++ b/libursa/src/signatures/ed25519/ed25519.rs
@@ -1,0 +1,77 @@
+use super::super::{KeyGenOption, SignatureScheme};
+use ed25519_dalek::{Keypair, PublicKey as PK, Signature};
+pub use ed25519_dalek::{
+    EXPANDED_SECRET_KEY_LENGTH as PRIVATE_KEY_SIZE, PUBLIC_KEY_LENGTH as PUBLIC_KEY_SIZE,
+    SIGNATURE_LENGTH as SIGNATURE_SIZE,
+};
+use keys::{PrivateKey, PublicKey};
+use rand::rngs::OsRng;
+use rand::SeedableRng;
+use rand_chacha::ChaChaRng;
+use sha2::Digest;
+use zeroize::Zeroize;
+
+use CryptoError;
+
+pub const ALGORITHM_NAME: &str = "ED25519_SHA2_512";
+
+pub struct Ed25519Sha512;
+
+impl SignatureScheme for Ed25519Sha512 {
+    fn new() -> Self {
+        Self
+    }
+    fn keypair(
+        &self,
+        option: Option<KeyGenOption>,
+    ) -> Result<(PublicKey, PrivateKey), CryptoError> {
+        let kp = match option {
+            Some(mut o) => match o {
+                KeyGenOption::UseSeed(ref mut s) => {
+                    let hash = sha2::Sha256::digest(s.as_slice());
+                    s.zeroize();
+                    let mut rng = ChaChaRng::from_seed(*array_ref!(hash.as_slice(), 0, 32));
+                    Keypair::generate(&mut rng)
+                }
+                KeyGenOption::FromSecretKey(ref s) => Keypair::from_bytes(&s[..])
+                    .map_err(|e| CryptoError::KeyGenError(e.to_string()))?,
+            },
+            None => {
+                let mut rng =
+                    OsRng::new().map_err(|e| CryptoError::KeyGenError(e.msg.to_string()))?;
+                Keypair::generate(&mut rng)
+            }
+        };
+        Ok((
+            PublicKey(kp.public.to_bytes().to_vec()),
+            PrivateKey(kp.to_bytes().to_vec()),
+        ))
+    }
+    fn sign(&self, message: &[u8], sk: &PrivateKey) -> Result<Vec<u8>, CryptoError> {
+        let kp =
+            Keypair::from_bytes(&sk[..]).map_err(|e| CryptoError::KeyGenError(e.to_string()))?;
+        Ok(kp.sign(message).to_bytes().to_vec())
+    }
+    fn verify(
+        &self,
+        message: &[u8],
+        signature: &[u8],
+        pk: &PublicKey,
+    ) -> Result<bool, CryptoError> {
+        let p = PK::from_bytes(&pk[..]).map_err(|e| CryptoError::ParseError(e.to_string()))?;
+        let s =
+            Signature::from_bytes(signature).map_err(|e| CryptoError::ParseError(e.to_string()))?;
+        p.verify(message, &s)
+            .map_err(|e| CryptoError::SigningError(e.to_string()))?;
+        Ok(true)
+    }
+    fn signature_size() -> usize {
+        SIGNATURE_SIZE
+    }
+    fn private_key_size() -> usize {
+        PRIVATE_KEY_SIZE
+    }
+    fn public_key_size() -> usize {
+        PUBLIC_KEY_SIZE
+    }
+}

--- a/libursa/src/signatures/ed25519/ed25519_wasm.rs
+++ b/libursa/src/signatures/ed25519/ed25519_wasm.rs
@@ -1,0 +1,90 @@
+use super::super::*;
+use super::*;
+
+use crypto;
+use keys::{KeyGenOption, PrivateKey, PublicKey};
+use rand::{rngs::OsRng, RngCore, SeedableRng};
+use rand_chacha::ChaChaRng;
+use sha2::Digest;
+use zeroize::Zeroize;
+use CryptoError;
+
+#[derive(Serialize, Deserialize)]
+pub struct Ed25519Sha512;
+
+impl Ed25519Sha512 {
+    pub fn keypair(option: Option<KeyGenOption>) -> Result<(PublicKey, PrivateKey), CryptoError> {
+        let s = Ed25519Sha512 {};
+        s.keypair(option)
+    }
+
+    pub fn sign(message: &[u8], sk: &PrivateKey) -> Result<Vec<u8>, CryptoError> {
+        let s = Ed25519Sha512 {};
+        s.sign(message, sk)
+    }
+
+    pub fn verify(message: &[u8], signature: &[u8], pk: &PublicKey) -> Result<bool, CryptoError> {
+        let s = Ed25519Sha512 {};
+        s.verify(message, signature, pk)
+    }
+}
+
+impl SignatureScheme for Ed25519Sha512 {
+    fn new() -> Self {
+        Self
+    }
+    fn keypair(
+        &self,
+        option: Option<KeyGenOption>,
+    ) -> Result<(PublicKey, PrivateKey), CryptoError> {
+        let (sk, pk) = match option {
+            Some(ref o) => match o {
+                KeyGenOption::UseSeed(ref s) => {
+                    let hash = sha2::Sha256::digest(s.as_slice());
+                    let mut rng = ChaChaRng::from_seed(*array_ref!(hash.as_slice(), 0, 32));
+                    let mut seed = [0u8; PRIVATE_KEY_SIZE];
+                    rng.fill_bytes(&mut seed);
+                    let pair = crypto::ed25519::keypair(&seed);
+                    seed.zeroize();
+                    pair
+                }
+                KeyGenOption::FromSecretKey(ref s) => {
+                    (*array_ref!(s, 0, 64), *array_ref!(s, 32, 32))
+                }
+            },
+            None => {
+                let mut rng =
+                    OsRng::new().map_err(|err| CryptoError::KeyGenError(format!("{}", err)))?;
+                let mut seed = [0u8; 32];
+                rng.fill_bytes(&mut seed);
+                crypto::ed25519::keypair(&seed)
+            }
+        };
+        Ok((PublicKey(pk.to_vec()), PrivateKey(sk.to_vec())))
+    }
+    fn sign(&self, message: &[u8], sk: &PrivateKey) -> Result<Vec<u8>, CryptoError> {
+        Ok(crypto::ed25519::signature(message, &sk[..]).to_vec())
+    }
+    fn verify(
+        &self,
+        message: &[u8],
+        signature: &[u8],
+        pk: &PublicKey,
+    ) -> Result<bool, CryptoError> {
+        if signature.len() != SIGNATURE_SIZE {
+            return Err(CryptoError::ParseError(
+                "Invalid signature length".to_string(),
+            ));
+        }
+        Ok(crypto::ed25519::verify(message, &pk[..], signature))
+    }
+    fn signature_size() -> usize {
+        SIGNATURE_SIZE
+    }
+    fn private_key_size() -> usize {
+        PRIVATE_KEY_SIZE
+    }
+    fn public_key_size() -> usize {
+        PUBLIC_KEY_SIZE
+    }
+}

--- a/libursa/src/signatures/ed25519/mod.rs
+++ b/libursa/src/signatures/ed25519/mod.rs
@@ -1,85 +1,22 @@
-use super::{KeyGenOption, PrivateKey, PublicKey, SignatureScheme};
-use ed25519_dalek::{Keypair, PublicKey as PK, Signature};
-pub use ed25519_dalek::{
-    EXPANDED_SECRET_KEY_LENGTH as PRIVATE_KEY_SIZE, PUBLIC_KEY_LENGTH as PUBLIC_KEY_SIZE,
-    SIGNATURE_LENGTH as SIGNATURE_SIZE,
-};
-use rand::rngs::OsRng;
-use rand::SeedableRng;
-use rand_chacha::ChaChaRng;
-use sha2::Digest;
-use zeroize::Zeroize;
-use CryptoError;
+#[cfg(not(feature = "wasm"))]
+#[path = "ed25519.rs"]
+pub mod ed25519;
+#[cfg(feature = "wasm")]
+#[path = "ed25519_wasm.rs"]
+pub mod ed25519;
 
+pub const PRIVATE_KEY_SIZE: usize = 64;
+pub const PUBLIC_KEY_SIZE: usize = 32;
+pub const SIGNATURE_SIZE: usize = 64;
 pub const ALGORITHM_NAME: &str = "ED25519_SHA2_512";
-
-#[cfg_attr(feature = "wasm", derive(Serialize, Deserialize))]
-pub struct Ed25519Sha512;
-
-impl SignatureScheme for Ed25519Sha512 {
-    fn new() -> Self {
-        Self
-    }
-    fn keypair(
-        &self,
-        option: Option<KeyGenOption>,
-    ) -> Result<(PublicKey, PrivateKey), CryptoError> {
-        let kp = match option {
-            Some(mut o) => match o {
-                KeyGenOption::UseSeed(ref mut s) => {
-                    let hash = sha2::Sha256::digest(s.as_slice());
-                    s.zeroize();
-                    let mut rng = ChaChaRng::from_seed(*array_ref!(hash.as_slice(), 0, 32));
-                    Keypair::generate(&mut rng)
-                }
-                KeyGenOption::FromSecretKey(ref s) => Keypair::from_bytes(&s[..])
-                    .map_err(|e| CryptoError::KeyGenError(e.to_string()))?,
-            },
-            None => {
-                let mut rng =
-                    OsRng::new().map_err(|e| CryptoError::KeyGenError(e.msg.to_string()))?;
-                Keypair::generate(&mut rng)
-            }
-        };
-        Ok((
-            PublicKey(kp.public.to_bytes().to_vec()),
-            PrivateKey(kp.to_bytes().to_vec()),
-        ))
-    }
-    fn sign(&self, message: &[u8], sk: &PrivateKey) -> Result<Vec<u8>, CryptoError> {
-        let kp =
-            Keypair::from_bytes(&sk[..]).map_err(|e| CryptoError::KeyGenError(e.to_string()))?;
-        Ok(kp.sign(message).to_bytes().to_vec())
-    }
-    fn verify(
-        &self,
-        message: &[u8],
-        signature: &[u8],
-        pk: &PublicKey,
-    ) -> Result<bool, CryptoError> {
-        let p = PK::from_bytes(&pk[..]).map_err(|e| CryptoError::ParseError(e.to_string()))?;
-        let s =
-            Signature::from_bytes(signature).map_err(|e| CryptoError::ParseError(e.to_string()))?;
-        p.verify(message, &s)
-            .map_err(|e| CryptoError::SigningError(e.to_string()))?;
-        Ok(true)
-    }
-    fn signature_size() -> usize {
-        SIGNATURE_SIZE
-    }
-    fn private_key_size() -> usize {
-        PRIVATE_KEY_SIZE
-    }
-    fn public_key_size() -> usize {
-        PUBLIC_KEY_SIZE
-    }
-}
 
 #[cfg(test)]
 mod test {
-    use super::super::Signer;
+    use self::ed25519::Ed25519Sha512;
+    use super::super::{SignatureScheme, Signer};
     use super::*;
-    use encoding::hex::{bin2hex, hex2bin};
+    use hex;
+    use keys::{KeyGenOption, PrivateKey, PublicKey};
     use libsodium_ffi as ffi;
 
     const MESSAGE_1: &[u8] = b"This is a dummy message for use with tests";
@@ -100,28 +37,28 @@ mod test {
     #[test]
     fn ed25519_load_keys() {
         let scheme = Ed25519Sha512::new();
-        let secret = PrivateKey(hex2bin(PRIVATE_KEY).unwrap());
+        let secret = PrivateKey(hex::decode(PRIVATE_KEY).unwrap());
         let sres = scheme.keypair(Some(KeyGenOption::FromSecretKey(secret)));
         assert!(sres.is_ok());
         let (p1, s1) = sres.unwrap();
-        assert_eq!(s1, PrivateKey(hex2bin(PRIVATE_KEY).unwrap()));
-        assert_eq!(p1, PublicKey(hex2bin(PUBLIC_KEY).unwrap()));
+        assert_eq!(s1, PrivateKey(hex::decode(PRIVATE_KEY).unwrap()));
+        assert_eq!(p1, PublicKey(hex::decode(PUBLIC_KEY).unwrap()));
     }
 
     #[test]
     fn ed25519_verify() {
         let scheme = Ed25519Sha512::new();
-        let secret = PrivateKey(hex2bin(PRIVATE_KEY).unwrap());
+        let secret = PrivateKey(hex::decode(PRIVATE_KEY).unwrap());
         let (p, _) = scheme
             .keypair(Some(KeyGenOption::FromSecretKey(secret)))
             .unwrap();
 
-        let result = scheme.verify(&MESSAGE_1, hex2bin(SIGNATURE_1).unwrap().as_slice(), &p);
+        let result = scheme.verify(&MESSAGE_1, hex::decode(SIGNATURE_1).unwrap().as_slice(), &p);
         assert!(result.is_ok());
         assert!(result.unwrap());
 
         //Check if signatures produced here can be verified by libsodium
-        let signature = hex2bin(SIGNATURE_1).unwrap();
+        let signature = hex::decode(SIGNATURE_1).unwrap();
         let res = unsafe {
             ffi::crypto_sign_ed25519_verify_detached(
                 signature.as_slice().as_ptr() as *const u8,
@@ -136,7 +73,7 @@ mod test {
     #[test]
     fn ed25519_sign() {
         let scheme = Ed25519Sha512::new();
-        let secret = PrivateKey(hex2bin(PRIVATE_KEY).unwrap());
+        let secret = PrivateKey(hex::decode(PRIVATE_KEY).unwrap());
         let (p, s) = scheme
             .keypair(Some(KeyGenOption::FromSecretKey(secret)))
             .unwrap();
@@ -148,7 +85,7 @@ mod test {
                 assert!(result.unwrap());
 
                 assert_eq!(sig.len(), SIGNATURE_SIZE);
-                assert_eq!(bin2hex(sig.as_slice()), SIGNATURE_1);
+                assert_eq!(hex::encode(sig.as_slice()), SIGNATURE_1);
 
                 //Check if libsodium signs the message and this module still can verify it
                 //And that private keys can sign with other libraries

--- a/libursa/src/signatures/mod.rs
+++ b/libursa/src/signatures/mod.rs
@@ -1,6 +1,13 @@
 pub mod ed25519;
 pub mod secp256k1;
 
+pub mod prelude {
+    pub use super::{
+        ed25519::ed25519::Ed25519Sha512, secp256k1::EcdsaSecp256k1Sha256, EcdsaPublicKeyHandler,
+        SignatureScheme, Signer,
+    };
+}
+
 use keys::{KeyGenOption, PrivateKey, PublicKey};
 use CryptoError;
 

--- a/libursa/src/signatures/secp256k1.rs
+++ b/libursa/src/signatures/secp256k1.rs
@@ -4,9 +4,9 @@ use CryptoError;
 
 use rand::rngs::OsRng;
 
-#[cfg(feature = "portable")]
+#[cfg(feature = "wasm")]
 use serde::de::{Deserialize, Deserializer, Error as DError, Visitor};
-#[cfg(feature = "portable")]
+#[cfg(feature = "wasm")]
 use serde::ser::{Serialize, Serializer};
 
 pub const PRIVATE_KEY_SIZE: usize = 32;
@@ -74,7 +74,7 @@ impl EcdsaPublicKeyHandler for EcdsaSecp256k1Sha256 {
     }
 }
 
-#[cfg(feature = "portable")]
+#[cfg(feature = "wasm")]
 impl Serialize for EcdsaSecp256k1Sha256 {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -84,7 +84,7 @@ impl Serialize for EcdsaSecp256k1Sha256 {
     }
 }
 
-#[cfg(feature = "portable")]
+#[cfg(feature = "wasm")]
 impl<'a> Deserialize<'a> for EcdsaSecp256k1Sha256 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -111,7 +111,7 @@ impl<'a> Deserialize<'a> for EcdsaSecp256k1Sha256 {
     }
 }
 
-#[cfg(all(feature = "native", not(feature = "portable")))]
+#[cfg(all(feature = "native", not(any(feature = "portable", feature = "wasm"))))]
 mod ecdsa_secp256k1 {
     use super::*;
     use libsecp256k1;
@@ -218,7 +218,7 @@ mod ecdsa_secp256k1 {
     }
 }
 
-#[cfg(all(feature = "portable", not(feature = "native")))]
+#[cfg(all(any(feature = "portable", feature = "wasm"), not(feature = "native")))]
 mod ecdsa_secp256k1 {
     use super::*;
     use rustlibsecp256k1;

--- a/libursa/src/wasm/cl.rs
+++ b/libursa/src/wasm/cl.rs
@@ -426,8 +426,9 @@ impl ProofVerifier {
     }
 
     pub fn verify(&self, proof: &Proof, nonce: &Nonce) -> Result<bool, JsValue> {
-        let res = maperr!(self.0.verify(&proof.0, &nonce.0));
-        Ok(res)
+//        let res = maperr!(self.0.verify(&proof.0, &nonce.0));
+//        Ok(res)
+        unimplemented!();
     }
 }
 

--- a/libursa/src/wasm/ed25519.rs
+++ b/libursa/src/wasm/ed25519.rs
@@ -1,47 +1,49 @@
-use keys::{KeyGenOption, PrivateKey, PublicKey};
-use signatures::ed25519::Ed25519Sha512 as Ed25519Sha512Impl;
-use signatures::SignatureScheme;
+use keys::KeyGenOption;
+use signatures::prelude::Ed25519Sha512 as Ed25519Sha512Impl;
 
 use wasm_bindgen::prelude::*;
 
 use super::{KeyPair, WasmPrivateKey, WasmPublicKey};
 
 #[wasm_bindgen]
-pub struct Ed25519Sha512(Ed25519Sha512Impl);
+pub struct Ed25519Sha512;
 
 #[wasm_bindgen]
 #[allow(non_snake_case)]
 impl Ed25519Sha512 {
-    pub fn new() -> Ed25519Sha512 {
-        Ed25519Sha512(Ed25519Sha512Impl::new())
+    pub fn new() -> Self {
+        Self
     }
 
     pub fn keypair(&self) -> Result<KeyPair, JsValue> {
-        let (pk, sk) = maperr!(self.0.keypair(None));
-        let pk = WasmPublicKey::from(&pk);
-        let sk = WasmPrivateKey::from(&sk);
-        Ok(KeyPair { pk, sk })
+        let (pk, sk) = maperr!(Ed25519Sha512Impl::keypair(None));
+        Ok(KeyPair {
+            pk: pk.into(),
+            sk: sk.into(),
+        })
     }
 
     pub fn keyPairFromSeed(&self, seed: &[u8]) -> Result<KeyPair, JsValue> {
-        let (pk, sk) = maperr!(self.0.keypair(Some(KeyGenOption::UseSeed(seed.to_vec()))));
-        let pk = WasmPublicKey::from(&pk);
-        let sk = WasmPrivateKey::from(&sk);
-        Ok(KeyPair { pk, sk })
+        let (pk, sk) = maperr!(Ed25519Sha512Impl::keypair(Some(KeyGenOption::UseSeed(
+            seed.to_vec()
+        ))));
+        Ok(KeyPair {
+            pk: pk.into(),
+            sk: sk.into(),
+        })
     }
 
     pub fn getPublicKey(&self, sk: &WasmPrivateKey) -> Result<WasmPublicKey, JsValue> {
-        let sk = PrivateKey::from(sk);
-        let (pk, _) = maperr!(self
-            .0
-            .keypair(Some(KeyGenOption::FromSecretKey(sk.clone()))));
-        let pk = WasmPublicKey::from(&pk);
-        Ok(pk)
+        let sk = sk.into();
+        let (pk, _) = maperr!(Ed25519Sha512Impl::keypair(Some(
+            KeyGenOption::FromSecretKey(sk)
+        )));
+        Ok(pk.into())
     }
 
     pub fn sign(&self, message: &[u8], sk: &WasmPrivateKey) -> Result<Vec<u8>, JsValue> {
-        let sk = PrivateKey::from(sk);
-        let sig = maperr!(self.0.sign(message, &sk));
+        let sk = sk.into();
+        let sig = maperr!(Ed25519Sha512Impl::sign(message, &sk));
         Ok(sig)
     }
 
@@ -51,7 +53,7 @@ impl Ed25519Sha512 {
         signature: &[u8],
         pk: &WasmPublicKey,
     ) -> Result<bool, JsValue> {
-        let pk = PublicKey::from(pk);
-        Ok(maperr!(self.0.verify(message, signature, &pk)))
+        let pk = pk.into();
+        Ok(maperr!(Ed25519Sha512Impl::verify(message, signature, &pk)))
     }
 }

--- a/libursa/src/wasm/mod.rs
+++ b/libursa/src/wasm/mod.rs
@@ -6,10 +6,9 @@ pub mod bls;
 pub mod ed25519;
 pub mod secp256k1;
 
-#[cfg(feature = "cl")]
-pub mod cl;
+//#[cfg(feature = "cl")]
+//pub mod cl;
 
-use encoding::hex::{bin2hex, hex2bin};
 use keys::{PrivateKey, PublicKey};
 
 use errors::{UrsaCryptoError, UrsaCryptoErrorKind};
@@ -32,31 +31,54 @@ pub struct KeyPair {
 
 impl From<&PublicKey> for WasmPublicKey {
     fn from(pk: &PublicKey) -> WasmPublicKey {
-        WasmPublicKey(bin2hex(&pk[..]))
+        WasmPublicKey(hex::encode(&pk[..]))
+    }
+}
+
+impl From<PublicKey> for WasmPublicKey {
+    fn from(pk: PublicKey) -> WasmPublicKey {
+        WasmPublicKey(hex::encode(&pk[..]))
     }
 }
 
 impl From<Vec<u8>> for WasmPublicKey {
     fn from(value: Vec<u8>) -> WasmPublicKey {
-        WasmPublicKey(bin2hex(value.as_slice()))
+        WasmPublicKey(hex::encode(value.as_slice()))
     }
 }
 
 impl From<&WasmPublicKey> for PublicKey {
     fn from(pk: &WasmPublicKey) -> PublicKey {
-        PublicKey(hex2bin(&pk.0).unwrap().to_vec())
+        PublicKey(hex::decode(&pk.0).unwrap().to_vec())
+    }
+}
+impl From<WasmPublicKey> for PublicKey {
+    fn from(pk: WasmPublicKey) -> PublicKey {
+        PublicKey(hex::decode(&pk.0).unwrap().to_vec())
     }
 }
 
 impl From<&PrivateKey> for WasmPrivateKey {
     fn from(sk: &PrivateKey) -> WasmPrivateKey {
-        WasmPrivateKey(bin2hex(&sk[..]))
+        WasmPrivateKey(hex::encode(&sk[..]))
+    }
+}
+
+impl From<PrivateKey> for WasmPrivateKey {
+    fn from(sk: PrivateKey) -> WasmPrivateKey {
+        WasmPrivateKey(hex::encode(&sk[..]))
     }
 }
 
 impl From<&WasmPrivateKey> for PrivateKey {
     fn from(pk: &WasmPrivateKey) -> PrivateKey {
-        PrivateKey(hex2bin(&pk.0).unwrap().to_vec())
+        PrivateKey(hex::decode(&pk.0).unwrap().to_vec())
+    }
+}
+
+impl From<WasmPrivateKey> for PrivateKey {
+    fn from(pk: WasmPrivateKey) -> PrivateKey {
+        PrivateKey(hex::decode(&pk.0).unwrap().to_vec())
     }
 }
 


### PR DESCRIPTION
This fixes many of the packing and building issues that ursa had for WASM. It should work now on any OS that has Cargo and Wasm-Pack installed.