### PR TITLE
Upgrade aead/aes-gcm/chacha20poly1305 crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7,7 +7,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "aead"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "generic-array 0.12.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -25,10 +25,10 @@ dependencies = [
 
 [[package]]
 name = "aes-gcm"
-version = "0.1.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aead 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aead 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "aes 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ghash 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "subtle 2.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -299,21 +299,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "chacha20"
-version = "0.2.3"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "salsa20-core 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "stream-cipher 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.2.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aead 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "chacha20 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aead 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chacha20 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "poly1305 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1248,15 +1247,6 @@ version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "salsa20-core"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "stream-cipher 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "zeroize 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "same-file"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1504,9 +1494,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "ursa"
 version = "0.3.0"
 dependencies = [
- "aead 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aead 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "aes 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "aes-gcm 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aes-gcm 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "amcl 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "amcl_wrapper 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1514,7 +1504,7 @@ dependencies = [
  "block-modes 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "block-padding 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytebuffer-rs 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "chacha20poly1305 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "chacha20poly1305 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "console_error_panic_hook 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "criterion 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ed25519-dalek 1.0.0-pre.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1736,9 +1726,9 @@ dependencies = [
 
 [metadata]
 "checksum adler32 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
-"checksum aead 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "529ae27769da55d955d190396e67896f49b440aff94a5b2f50900e091d168b77"
+"checksum aead 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4cf01b9b56e767bb57b94ebf91a58b338002963785cdd7013e21c0d4679471e4"
 "checksum aes 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "54eb1d8fe354e5fc611daf4f2ea97dd45a765f4f1e4512306ec183ae2e8f20c9"
-"checksum aes-gcm 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3c6e030ead0fe69f0346091ed4b5b01c9610d42bf6d2a283036132485094793c"
+"checksum aes-gcm 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4001f31800fc9b8c774728f82c7348f4f91474afd38c12a0e7dfa8303ae2dbd6"
 "checksum aes-soft 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "cfd7e7ae3f9a1fb5c03b389fc6bb9a51400d0c13053f0dca698c832bfd893a0d"
 "checksum aesni 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f70a6b5f971e473091ab7cfb5ffac6cde81666c4556751d8d5620ead8abf100"
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
@@ -1769,8 +1759,8 @@ dependencies = [
 "checksum cast 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0"
 "checksum cc 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)" = "8dae9c4b8fedcae85592ba623c4fd08cfdab3e3b72d6df780c6ead964a69bfff"
 "checksum cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-"checksum chacha20 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "600b18f1de4dbea5ffa2902f259038364e48420d0d6e6a60ed5a3e075c7d4efb"
-"checksum chacha20poly1305 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9c5934c9a6ea3dc783dd2d38ae9d6e535856d80078af077b8bc4dbca0ff7f17a"
+"checksum chacha20 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1f55d399a623e8f2fcc7c7974100836e10168c4ce92fdb18f58d3a11532ad35c"
+"checksum chacha20poly1305 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4d7c7def9c4e6f11a5b7525585853135689865907ca3c4c34e0a4b252fd50dd0"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum clear_on_drop 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "97276801e127ffb46b66ce23f35cc96bd454fa311294bced4bbace7baa8b1d17"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
@@ -1877,7 +1867,6 @@ dependencies = [
 "checksum rustc-demangle 0.1.16 (registry+https://github.com/rust-lang/crates.io-index)" = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum ryu 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bfa8506c1de11c9c4e4c38863ccbe02a305c8188e85a05a784c9e11e1c3910c8"
-"checksum salsa20-core 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2fe6cc1b9f5a5867853ade63099de70f042f7679e408d1ffe52821c9248e6e69"
 "checksum same-file 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "585e8ddcedc187886a30fa705c47985c3fa88d06624095856b36ca0b82ff4421"
 "checksum scopeguard 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
 "checksum secp256k1 0.15.5 (registry+https://github.com/rust-lang/crates.io-index)" = "4d311229f403d64002e9eed9964dfa5a0a0c1ac443344f7546bf48e916c6053a"

--- a/libursa/Cargo.toml
+++ b/libursa/Cargo.toml
@@ -88,9 +88,9 @@ std = ["sha2/std", "sha3", "blake2/std", "ed25519-dalek/std", "ed25519-dalek/u64
 wasm = ["wasm-bindgen", "console_error_panic_hook", "pair_amcl", "bn_rust", "serialization", "rustlibsecp256k1", "bls", "blake2/std", "sha2/std", "sha3", "js-sys", "rust-crypto-wasm", "encryption"]
 
 [dependencies]
-aead = { version = "0.1", optional = true }
+aead = { version = "0.2", optional = true }
 aes = { version = "0.3", optional = true }
-aes-gcm = { version = "0.1.0", optional = true }
+aes-gcm = { version = "0.3.0", optional = true }
 amcl = { version = "0.2",  optional = true, default-features = false, features = ["bn254", "secp256k1"]}
 amcl_wrapper = {version = "0.1.7", features = ["bls381"] }
 arrayref = "0.3.5"
@@ -118,7 +118,7 @@ openssl = { version = "0.10", optional = true }
 # TODO: Find out if the wasm-bindgen feature can be made dependent on our own wasm feature
 rand = { version = "0.6", features = ["wasm-bindgen"] }
 rand_chacha = "0.1"
-rustchacha20poly1305 = { version = "0.2.1", package = "chacha20poly1305", optional = true }
+rustchacha20poly1305 = { version = "0.3.1", package = "chacha20poly1305", optional = true }
 rustlibsecp256k1 = { version = "0.3", package = "libsecp256k1", optional = true }
 rust-crypto-wasm = { version = "0.3.1", optional = true }
 secp256k1 = { version = "0.15", optional = true, features = ["rand", "serde"]}

--- a/libursa/src/encryption/symm/aescbc.rs
+++ b/libursa/src/encryption/symm/aescbc.rs
@@ -101,6 +101,27 @@ macro_rules! aes_cbc_hmac_impl {
                     Err(Error)
                 }
             }
+
+            // TODO
+            fn encrypt_in_place_detached(
+                &self,
+                _nonce: &GenericArray<u8, Self::NonceSize>,
+                _associated_data: &[u8],
+                _buffer: &mut [u8],
+            ) -> Result<GenericArray<u8, Self::TagSize>, Error> {
+                unimplemented!();
+            }
+
+            // TODO
+            fn decrypt_in_place_detached(
+                &self,
+                _nonce: &GenericArray<u8, Self::NonceSize>,
+                _associated_data: &[u8],
+                _buffer: &mut [u8],
+                _tag: &GenericArray<u8, Self::TagSize>,
+            ) -> Result<(), Error> {
+                unimplemented!();
+            }
         }
 
         default_impl!($name);

--- a/libursa/src/encryption/symm/aescbc_asm.rs
+++ b/libursa/src/encryption/symm/aescbc_asm.rs
@@ -99,6 +99,27 @@ macro_rules! aes_cbc_hmac_impl {
                     Err(Error)
                 }
             }
+
+            // TODO
+            fn encrypt_in_place_detached(
+                &self,
+                _nonce: &GenericArray<u8, Self::NonceSize>,
+                _associated_data: &[u8],
+                _buffer: &mut [u8],
+            ) -> Result<GenericArray<u8, Self::TagSize>, Error> {
+                unimplemented!();
+            }
+
+            // TODO
+            fn decrypt_in_place_detached(
+                &self,
+                _nonce: &GenericArray<u8, Self::NonceSize>,
+                _associated_data: &[u8],
+                _buffer: &mut [u8],
+                _tag: &GenericArray<u8, Self::TagSize>,
+            ) -> Result<(), Error> {
+                unimplemented!();
+            }
         }
 
         default_impl!($name);

--- a/libursa/src/encryption/symm/aesgcm.rs
+++ b/libursa/src/encryption/symm/aesgcm.rs
@@ -56,6 +56,27 @@ macro_rules! aes_gcm_impl {
                 let aes = $algoname::new(self.key);
                 aes.decrypt(nonce, payload)
             }
+
+            // TODO
+            fn encrypt_in_place_detached(
+                &self,
+                _nonce: &GenericArray<u8, Self::NonceSize>,
+                _associated_data: &[u8],
+                _buffer: &mut [u8],
+            ) -> Result<GenericArray<u8, Self::TagSize>, Error> {
+                unimplemented!();
+            }
+
+            // TODO
+            fn decrypt_in_place_detached(
+                &self,
+                _nonce: &GenericArray<u8, Self::NonceSize>,
+                _associated_data: &[u8],
+                _buffer: &mut [u8],
+                _tag: &GenericArray<u8, Self::TagSize>,
+            ) -> Result<(), Error> {
+                unimplemented!();
+            }
         }
 
         default_impl!($name);

--- a/libursa/src/encryption/symm/aesgcm_asm.rs
+++ b/libursa/src/encryption/symm/aesgcm_asm.rs
@@ -78,6 +78,27 @@ macro_rules! aes_gcm_impl {
                 .map_err(|_| Error)?;
                 Ok(plaintext)
             }
+
+            // TODO
+            fn encrypt_in_place_detached(
+                &self,
+                _nonce: &GenericArray<u8, Self::NonceSize>,
+                _associated_data: &[u8],
+                _buffer: &mut [u8],
+            ) -> Result<GenericArray<u8, Self::TagSize>, Error> {
+                unimplemented!();
+            }
+
+            // TODO
+            fn decrypt_in_place_detached(
+                &self,
+                _nonce: &GenericArray<u8, Self::NonceSize>,
+                _associated_data: &[u8],
+                _buffer: &mut [u8],
+                _tag: &GenericArray<u8, Self::TagSize>,
+            ) -> Result<(), Error> {
+                unimplemented!();
+            }
         }
 
         default_impl!($name);

--- a/libursa/src/encryption/symm/xchacha20poly1305.rs
+++ b/libursa/src/encryption/symm/xchacha20poly1305.rs
@@ -49,6 +49,27 @@ impl Aead for XChaCha20Poly1305 {
         let plaintext = aead.decrypt(nonce, ciphertext)?;
         Ok(plaintext)
     }
+
+    // TODO
+    fn encrypt_in_place_detached(
+        &self,
+        _nonce: &GenericArray<u8, Self::NonceSize>,
+        _associated_data: &[u8],
+        _buffer: &mut [u8],
+    ) -> Result<GenericArray<u8, Self::TagSize>, Error> {
+        unimplemented!();
+    }
+
+    // TODO
+    fn decrypt_in_place_detached(
+        &self,
+        _nonce: &GenericArray<u8, Self::NonceSize>,
+        _associated_data: &[u8],
+        _buffer: &mut [u8],
+        _tag: &GenericArray<u8, Self::TagSize>,
+    ) -> Result<(), Error> {
+        unimplemented!();
+    }
 }
 
 default_impl!(XChaCha20Poly1305);

--- a/libursa/src/encryption/symm/xchacha20poly1305_asm.rs
+++ b/libursa/src/encryption/symm/xchacha20poly1305_asm.rs
@@ -101,6 +101,27 @@ impl Aead for XChaCha20Poly1305 {
         }
         Ok(plaintext)
     }
+
+    // TODO
+    fn encrypt_in_place_detached(
+        &self,
+        _nonce: &GenericArray<u8, Self::NonceSize>,
+        _associated_data: &[u8],
+        _buffer: &mut [u8],
+    ) -> Result<GenericArray<u8, Self::TagSize>, Error> {
+        unimplemented!();
+    }
+
+    // TODO
+    fn decrypt_in_place_detached(
+        &self,
+        _nonce: &GenericArray<u8, Self::NonceSize>,
+        _associated_data: &[u8],
+        _buffer: &mut [u8],
+        _tag: &GenericArray<u8, Self::TagSize>,
+    ) -> Result<(), Error> {
+        unimplemented!();
+    }
 }
 
 default_impl!(XChaCha20Poly1305);


### PR DESCRIPTION
Updates the following crates:

- `aead` => v0.2
- `aes-gcm` => v0.3.0
- `chacha20poly1305` => v0.3.1

The `aead` crate v0.2 adds mandatory in-place/detached APIs. Perhaps these should be split into an e.g. `AeadInPlace` trait, however for now they are stubbed out with `unimplemented!()`.