### PR TITLE
Upgrades version of ed25519-dalek

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,7 +94,7 @@ dependencies = [
  "byteorder",
  "lazy_static",
  "miracl_amcl",
- "rand 0.7.3",
+ "rand 0.7.0",
  "rayon",
  "serde",
  "serde_derive",
@@ -166,7 +166,7 @@ dependencies = [
  "hex",
  "hkdf",
  "pairing-plus",
- "rand 0.7.3",
+ "rand 0.7.0",
  "rayon",
  "serde",
  "serde-wasm-bindgen",
@@ -278,7 +278,7 @@ dependencies = [
  "failure",
  "lazy_static",
  "merlin",
- "rand 0.7.3",
+ "rand 0.7.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -330,6 +330,15 @@ dependencies = [
  "cc",
  "libc",
  "pkg-config",
+]
+
+[[package]]
+name = "c2-chacha"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "214238caa1bf3a496ec3392968969cab8549f96ff30652c9e56885329315f6bb"
+dependencies = [
+ "ppv-lite86",
 ]
 
 [[package]]
@@ -418,15 +427,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97276801e127ffb46b66ce23f35cc96bd454fa311294bced4bbace7baa8b1d17"
 dependencies = [
  "cc",
-]
-
-[[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags",
 ]
 
 [[package]]
@@ -613,6 +613,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "curve25519-dalek"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26778518a7f6cffa1d25a44b602b62b979bd88adb9e99ffec546998cf3404839"
+dependencies = [
+ "byteorder",
+ "digest",
+ "packed_simd",
+ "rand_core 0.5.1",
+ "subtle 2.2.2",
+ "zeroize",
+]
+
+[[package]]
 name = "digest"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -623,15 +637,13 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "1.0.0-pre.2"
+version = "1.0.0-pre.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "845aaacc16f01178f33349e7c992ecd0cee095aa5e577f0f4dee35971bd36455"
+checksum = "978710b352437433c97b2bff193f2fb1dfd58a093f863dd95e225a19baa599a2"
 dependencies = [
  "clear_on_drop",
- "curve25519-dalek",
- "failure",
- "rand_core 0.3.1",
- "rand_os",
+ "curve25519-dalek 2.0.0",
+ "rand 0.7.0",
  "sha2",
 ]
 
@@ -700,7 +712,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b24d4059bc0d0a0bf26b740aa21af1f96a984f0ab7a21356d00b32475388b53a"
 dependencies = [
- "num-bigint",
+ "num-bigint 0.2.6",
  "num-integer",
  "num-traits",
  "proc-macro2",
@@ -796,6 +808,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -815,15 +828,15 @@ checksum = "bcc8e0c9bce37868955864dbecd2b1ab2bdf967e6f28066d65aaac620444b65c"
 
 [[package]]
 name = "glass_pumpkin"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0e4ad2fc1040c455d7c0eb78e96bd81e7049167f7b0cf1aa7a23023e5d744a"
+checksum = "5eac7b86325ee905c72e2cb43a80b1ebe6ea82d7f0854d669190bcdc4b927762"
 dependencies = [
  "lazy_static",
- "num-bigint",
+ "num-bigint 0.3.0",
  "num-integer",
  "num-traits",
- "rand 0.6.5",
+ "rand 0.7.0",
 ]
 
 [[package]]
@@ -961,7 +974,7 @@ dependencies = [
  "crunchy",
  "digest",
  "hmac-drbg",
- "rand 0.7.3",
+ "rand 0.7.0",
  "sha2",
  "subtle 2.2.3",
  "typenum",
@@ -1071,7 +1084,18 @@ dependencies = [
  "autocfg 1.0.0",
  "num-integer",
  "num-traits",
- "rand 0.5.6",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f3fc75e3697059fb1bc465e3d8cca6cf92f56854f201158b3f9c77d5a3cfa0"
+dependencies = [
+ "autocfg 1.0.0",
+ "num-integer",
+ "num-traits",
+ "rand 0.7.0",
 ]
 
 [[package]]
@@ -1272,19 +1296,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
-dependencies = [
- "cloudabi",
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
@@ -1296,7 +1307,6 @@ dependencies = [
  "rand_hc 0.1.0",
  "rand_isaac",
  "rand_jitter",
- "rand_os",
  "rand_pcg",
  "rand_xorshift 0.1.1",
  "winapi",
@@ -1304,13 +1314,14 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+checksum = "d47eab0e83d9693d40f825f86948aa16eff6750ead4bdffc4ab95b8b3a7f052c"
 dependencies = [
  "getrandom",
  "libc",
- "rand_chacha 0.2.2",
+ "packed_simd",
+ "rand_chacha 0.2.0",
  "rand_core 0.5.1",
  "rand_hc 0.2.0",
 ]
@@ -1327,11 +1338,12 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.2.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+checksum = "e193067942ef6f485a349a113329140d0ab9e2168ce92274499bb0e9a4190d9d"
 dependencies = [
- "ppv-lite86",
+ "autocfg 0.1.7",
+ "c2-chacha",
  "rand_core 0.5.1",
 ]
 
@@ -1394,21 +1406,6 @@ checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
 dependencies = [
  "libc",
  "rand_core 0.4.2",
- "winapi",
-]
-
-[[package]]
-name = "rand_os"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
-dependencies = [
- "cloudabi",
- "fuchsia-cprng",
- "libc",
- "rand_core 0.4.2",
- "rdrand",
- "wasm-bindgen",
  "winapi",
 ]
 
@@ -1859,7 +1856,7 @@ dependencies = [
  "clear_on_drop",
  "console_error_panic_hook",
  "criterion",
- "curve25519-dalek",
+ "curve25519-dalek 1.2.3",
  "ed25519-dalek",
  "env_logger",
  "failure",
@@ -1873,12 +1870,12 @@ dependencies = [
  "libsecp256k1",
  "libsodium-ffi",
  "log",
- "num-bigint",
+ "num-bigint 0.3.0",
  "num-integer",
  "num-traits",
  "openssl",
- "rand 0.6.5",
- "rand_chacha 0.1.1",
+ "rand 0.7.0",
+ "rand_chacha 0.2.0",
  "secp256k1",
  "serde",
  "serde_json",
@@ -2034,13 +2031,13 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "x25519-dalek"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee1585dc1484373cbc1cee7aafda26634665cf449436fd6e24bfd1fad230538"
+checksum = "637ff90c9540fa3073bb577e65033069e4bae7c79d49d74aa3ffdf5342a53217"
 dependencies = [
- "clear_on_drop",
- "curve25519-dalek",
- "rand_core 0.3.1",
+ "curve25519-dalek 2.0.0",
+ "rand_core 0.5.1",
+ "zeroize",
 ]
 
 [[package]]
@@ -2099,8 +2096,8 @@ dependencies = [
  "hex",
  "lazy_static",
  "merlin",
- "rand 0.7.3",
- "rand_chacha 0.2.2",
+ "rand 0.7.0",
+ "rand_chacha 0.2.0",
  "serde",
  "serde_json",
  "sha2",

--- a/libursa/Cargo.toml
+++ b/libursa/Cargo.toml
@@ -86,7 +86,7 @@ ecdsa_secp256k1 = ["amcl", "arrayref", "failure", "hex", "rand", "rand_chacha", 
 ecdsa_secp256k1_native = ["arrayref", "failure", "hex", "log", "rand", "secp256k1", "rand_chacha", "sha2/std", "zeroize"]
 ecdsa_secp256k1_asm = ["arrayref", "failure", "hex", "log", "rand", "secp256k1", "rand_chacha", "sha2/asm", "zeroize"]
 ed25519 = ["arrayref", "ed25519-dalek/std", "ed25519-dalek/u64_backend", "hex", "rand", "rand_chacha", "sha2/std", "zeroize"]
-ed25519_asm = ["arrayref", "ed25519-dalek/nightly", "ed25519-dalek/avx2_backend", "hex", "rand", "rand_chacha", "sha2/asm", "zeroize"]
+ed25519_asm = ["arrayref", "ed25519-dalek/nightly", "ed25519-dalek/simd_backend", "hex", "rand", "rand_chacha", "sha2/asm", "zeroize"]
 encryption = ["aescbc", "aesgcm", "chacha20poly1305"]
 encryption_asm = ["aescbc_native", "aesgcm_native", "chacha20poly1305_native"]
 ffi = ["failure", "ffi-support", "logger", "serde", "serde_json", "time"]
@@ -118,11 +118,11 @@ block-padding = { version = "0.1", optional = true }
 clear_on_drop = { version = "0.2.3", optional = true }
 console_error_panic_hook = { version = "0.1.5", optional = true }
 curve25519-dalek = { version = "=1.2.3", default-features = false, optional = true }
-ed25519-dalek = { version = "=1.0.0-pre.2", default-features = false, optional = true }
+ed25519-dalek = { version = "=1.0.0-pre.3", default-features = false, optional = true }
 env_logger = { version = "0.7.0", optional = true }
 failure = { version = "0.1.6", optional = true }
 ffi-support = { version = "0.4", optional = true }
-glass_pumpkin = { version = "0.3", optional = true }
+glass_pumpkin = { version = "0.4", optional = true }
 hex = { version = "0.4.0", optional = true }
 hmac = { version = "0.7", optional = true }
 int_traits = { version = "0.1.1", optional = true }
@@ -130,13 +130,13 @@ js-sys = { version = "0.3.13", optional = true }
 lazy_static = { version = "1.4", optional = true }
 libsodium-ffi = { version = "0.2.2", optional = true }
 log = { version = "0.4.8", optional = true }
-num-bigint = { version = "0.2", features = ["rand"], optional = true }
-num-integer = { version = "0.1", optional = true }
-num-traits = { version = "0.2", optional = true }
+num-bigint = { version = "0.3.0", features = ["rand"], optional = true}
+num-integer = { version = "=0.1.42", optional = true }
+num-traits = { version = "=0.2.11", optional = true }
 openssl = { version = "0.10", optional = true }
 # TODO: Find out if the wasm-bindgen feature can be made dependent on our own wasm feature
-rand = { version = "=0.6.5", features = ["wasm-bindgen"], optional = true }
-rand_chacha = { version = "=0.1.1", optional = true }
+rand = { version = "=0.7", features = ["wasm-bindgen"], optional = true }
+rand_chacha = { version = "=0.2.0", optional = true }
 rustchacha20poly1305 = { version = "0.5.0", package = "chacha20poly1305", optional = true }
 rustlibsecp256k1 = { version = "0.3", package = "libsecp256k1", optional = true }
 secp256k1 = { version = "0.17", optional = true, features = ["rand", "serde"]}
@@ -147,7 +147,7 @@ sha3 = { version = "0.8", optional = true }
 subtle = { version = "2.2.1", optional = true }
 time = { version = "0.1", optional = true }
 wasm-bindgen = { version = "0.2", optional = true, features = ["serde-serialize"] }
-x25519-dalek = { version = "=0.5.2", optional = true, default-features = false }
+x25519-dalek = { version = "=0.6.0", optional = true, default-features = false }
 zeroize = { version = "1.1", features = ["zeroize_derive"], optional =  true }
 
 [dev-dependencies]

--- a/libursa/src/bn/rust.rs
+++ b/libursa/src/bn/rust.rs
@@ -72,7 +72,7 @@ impl BigNumber {
     ) -> UrsaCryptoResult<BigNumber> {
         let mut res;
         let mut iteration = 0;
-        let mut rng = OsRng::new()?;
+        let mut rng = OsRng::default();
         let mut start = match start.bn.to_biguint() {
             Some(bn) => bn,
             None => {
@@ -127,13 +127,13 @@ impl BigNumber {
     }
 
     pub fn rand(size: usize) -> UrsaCryptoResult<BigNumber> {
-        let mut rng = OsRng::new()?;
-        let res = rng.gen_biguint(size).to_bigint();
+        let mut rng = OsRng::default();
+        let res = rng.gen_biguint(size as u64).to_bigint();
         Ok(BigNumber { bn: res.unwrap() })
     }
 
     pub fn rand_range(&self) -> UrsaCryptoResult<BigNumber> {
-        let mut rng = OsRng::new()?;
+        let mut rng = OsRng::default();
         let res = rng.gen_bigint_range(&BigInt::zero(), &self.bn);
         match res.to_bigint() {
             Some(bn) => Ok(BigNumber { bn }),
@@ -356,7 +356,7 @@ impl BigNumber {
 
         match a.bn.to_u64() {
             Some(num) => Ok(BigNumber {
-                bn: self.bn.pow(num),
+                bn: self.bn.clone().pow(num),
             }),
             None => Err(UrsaCryptoError::from_msg(
                 UrsaCryptoErrorKind::InvalidState,

--- a/libursa/src/encryption/mod.rs
+++ b/libursa/src/encryption/mod.rs
@@ -9,8 +9,7 @@ pub mod symm;
 // Helpful for generating bytes using the operating system random number generator
 pub fn random_vec(bytes: usize) -> Result<Vec<u8>, Error> {
     let mut value = vec![0u8; bytes];
-    let mut rng = OsRng::new().map_err(|_| Error)?;
-    rng.fill_bytes(value.as_mut_slice());
+    OsRng.fill_bytes(value.as_mut_slice());
     Ok(value)
 }
 

--- a/libursa/src/kex/secp256k1.rs
+++ b/libursa/src/kex/secp256k1.rs
@@ -162,9 +162,7 @@ mod ecdh_secp256k1 {
                     KeyGenOption::FromSecretKey(ref s) => array_copy!(s, sk),
                 },
                 None => {
-                    let mut rng =
-                        OsRng::new().map_err(|err| CryptoError::KeyGenError(format!("{}", err)))?;
-                    rng.fill_bytes(&mut sk);
+                    OsRng.fill_bytes(&mut sk);
                     let d = D::digest(&sk[..]);
                     sk.clone_from_slice(d.as_slice());
                 }

--- a/libursa/src/kex/x25519.rs
+++ b/libursa/src/kex/x25519.rs
@@ -36,8 +36,7 @@ impl KeyExchangeScheme for X25519Sha256 {
                 }
             },
             None => {
-                let mut rng =
-                    OsRng::new().map_err(|e| CryptoError::KeyGenError(e.msg.to_string()))?;
+                let mut rng = OsRng::default();
                 let sk = StaticSecret::new(&mut rng);
                 let pk = X25519PublicKey::from(&sk);
                 (pk, sk)

--- a/libursa/src/signatures/ed25519.rs
+++ b/libursa/src/signatures/ed25519.rs
@@ -125,8 +125,7 @@ impl SignatureScheme for Ed25519Sha512 {
                     .map_err(|e| CryptoError::KeyGenError(e.to_string()))?,
             },
             None => {
-                let mut rng =
-                    OsRng::new().map_err(|e| CryptoError::KeyGenError(e.msg.to_string()))?;
+                let mut rng = OsRng::default();
                 Keypair::generate(&mut rng)
             }
         };

--- a/libursa/src/signatures/secp256k1.rs
+++ b/libursa/src/signatures/secp256k1.rs
@@ -161,10 +161,8 @@ mod ecdsa_secp256k1 {
                     }
                 },
                 None => {
-                    let mut rng =
-                        OsRng::new().map_err(|err| CryptoError::KeyGenError(format!("{}", err)))?;
                     let mut s = [0u8; PRIVATE_KEY_SIZE];
-                    rng.fill_bytes(&mut s);
+                    OsRng.fill_bytes(&mut s);
                     let k = D::digest(&s);
                     s.zeroize();
                     libsecp256k1::key::SecretKey::from_slice(k.as_slice())?
@@ -278,8 +276,7 @@ mod ecdsa_secp256k1 {
                     KeyGenOption::FromSecretKey(ref s) => array_copy!(s, sk),
                 },
                 None => {
-                    let mut rng =
-                        OsRng::new().map_err(|err| CryptoError::KeyGenError(format!("{}", err)))?;
+                    let mut rng = OsRng::default();
                     rng.fill_bytes(&mut sk);
                     let d = D::digest(&sk[..]);
                     sk.clone_from_slice(d.as_slice());


### PR DESCRIPTION
## Description of changes
Upgrade from 1.0.0-pre.2 to 1.0.0-pre.3
And corresponding fixes for other lib versions and src files

## Benefits
There is an issue with the usage of latest ursa (0.3.2) with latest libp2p(0.16.2): they have incompatible versions of ed25519-dalek (ursa - 1.0.0-pre.2 and libp2p - 1.0.0-pre.3). It could be solved only by downgrading libp2p to version 0.13.1 which is rather old now.

Therefore this PR is meant to fix that and make latest ursa and libp2p compatible, as they have rather intersecting user groups in my opinion.

Signed-off-by: Egor Ivkov <e.o.ivkov@gmail.com>