### PR TITLE
Fix warnings and update to 0.3.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -36,7 +36,7 @@ dependencies = [
  "aes",
  "ghash",
  "subtle 2.2.2",
- "zeroize 1.1.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -77,23 +77,6 @@ checksum = "ee5cca1ddc8b9dceb55b7f1272a9d1e643d73006f350a20ab4926d24e33f0f0d"
 
 [[package]]
 name = "amcl_wrapper"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0974eb4471489a1e1a40795e10a454d0af4f31929006591b5e6ac4026bb132b2"
-dependencies = [
- "byteorder",
- "lazy_static",
- "miracl_amcl",
- "rand 0.7.3",
- "serde",
- "serde_derive",
- "serde_json",
- "sha3",
- "zeroize 0.9.3",
-]
-
-[[package]]
-name = "amcl_wrapper"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ec0d9cc4f8750027c52bf97d9df7228d7d6e6a5a592dc3a7d11d411bae653f9"
@@ -108,7 +91,7 @@ dependencies = [
  "serde_json",
  "sha3",
  "subtle-encoding",
- "zeroize 1.1.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -187,8 +170,8 @@ dependencies = [
  "lazycell",
  "log",
  "peeking_take_while",
- "proc-macro2 1.0.9",
- "quote 1.0.3",
+ "proc-macro2",
+ "quote",
  "regex",
  "rustc-hash",
  "shlex",
@@ -269,7 +252,7 @@ dependencies = [
 name = "bulletproofs_amcl"
 version = "0.2.0"
 dependencies = [
- "amcl_wrapper 0.2.3",
+ "amcl_wrapper",
  "byteorder",
  "criterion",
  "failure",
@@ -365,7 +348,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6a7ae4c498f8447d86baef0fa0831909333f558866fabcb21600625ac5a31c7"
 dependencies = [
  "stream-cipher",
- "zeroize 1.1.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -377,7 +360,7 @@ dependencies = [
  "aead",
  "chacha20",
  "poly1305",
- "zeroize 1.1.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -665,10 +648,10 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "030a733c8287d6213886dd487564ff5c8f6aae10278b3588ed177f9d18f8d231"
 dependencies = [
- "proc-macro2 1.0.9",
- "quote 1.0.3",
- "syn 1.0.17",
- "synstructure 0.12.3",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -972,7 +955,7 @@ dependencies = [
  "byteorder",
  "keccak",
  "rand_core 0.4.2",
- "zeroize 1.1.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -1152,20 +1135,11 @@ checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 
 [[package]]
 name = "proc-macro2"
-version = "0.4.30"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
-dependencies = [
- "unicode-xid 0.1.0",
-]
-
-[[package]]
-name = "proc-macro2"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c09721c6781493a2a492a96b5a5bf19b65917fe6728884e7c44dd0c60ca3435"
 dependencies = [
- "unicode-xid 0.2.0",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1176,20 +1150,11 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "0.6.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
-dependencies = [
- "proc-macro2 0.4.30",
-]
-
-[[package]]
-name = "quote"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
 dependencies = [
- "proc-macro2 1.0.9",
+ "proc-macro2",
 ]
 
 [[package]]
@@ -1521,9 +1486,9 @@ version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac5d00fc561ba2724df6758a17de23df5914f20e41cb00f94d5b7ae42fffaff8"
 dependencies = [
- "proc-macro2 1.0.9",
- "quote 1.0.3",
- "syn 1.0.17",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1623,18 +1588,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dcb1ed7b8330c5eed5441052651dd7a12c75e2ed88f2ec024ae1fa3a5e59945"
 dependencies = [
- "zeroize 1.1.0",
-]
-
-[[package]]
-name = "syn"
-version = "0.15.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "unicode-xid 0.1.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -1643,21 +1597,9 @@ version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0df0eb663f387145cab623dea85b09c2c5b4b0aef44e945d928e682fce71bb03"
 dependencies = [
- "proc-macro2 1.0.9",
- "quote 1.0.3",
- "unicode-xid 0.2.0",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
- "unicode-xid 0.1.0",
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1666,10 +1608,10 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
 dependencies = [
- "proc-macro2 1.0.9",
- "quote 1.0.3",
- "syn 1.0.17",
- "unicode-xid 0.2.0",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1746,12 +1688,6 @@ checksum = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 
 [[package]]
 name = "unicode-xid"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-
-[[package]]
-name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
@@ -1780,7 +1716,7 @@ dependencies = [
  "aes",
  "aes-gcm",
  "amcl",
- "amcl_wrapper 0.3.5",
+ "amcl_wrapper",
  "arrayref",
  "blake2",
  "block-modes",
@@ -1819,7 +1755,7 @@ dependencies = [
  "time",
  "wasm-bindgen",
  "x25519-dalek",
- "zeroize 1.1.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -1878,9 +1814,9 @@ dependencies = [
  "bumpalo",
  "lazy_static",
  "log",
- "proc-macro2 1.0.9",
- "quote 1.0.3",
- "syn 1.0.17",
+ "proc-macro2",
+ "quote",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -1890,7 +1826,7 @@ version = "0.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bd151b63e1ea881bb742cd20e1d6127cef28399558f3b5d415289bc41eee3a4"
 dependencies = [
- "quote 1.0.3",
+ "quote",
  "wasm-bindgen-macro-support",
 ]
 
@@ -1900,9 +1836,9 @@ version = "0.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d68a5b36eef1be7868f668632863292e37739656a80fc4b9acec7b0bd35a4931"
 dependencies = [
- "proc-macro2 1.0.9",
- "quote 1.0.3",
- "syn 1.0.17",
+ "proc-macro2",
+ "quote",
+ "syn",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1985,32 +1921,11 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45af6a010d13e4cf5b54c94ba5a2b2eba5596b9e46bf5875612d332a1f2b3f86"
-dependencies = [
- "zeroize_derive 0.9.3",
-]
-
-[[package]]
-name = "zeroize"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cbac2ed2ba24cc90f5e06485ac8c7c1e5449fe8911aef4d8877218af021a5b8"
 dependencies = [
- "zeroize_derive 1.0.0",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "080616bd0e31f36095288bb0acdf1f78ef02c2fa15527d7e993f2a6c7591643e"
-dependencies = [
- "proc-macro2 0.4.30",
- "quote 0.6.13",
- "syn 0.15.44",
- "synstructure 0.10.2",
+ "zeroize_derive",
 ]
 
 [[package]]
@@ -2019,10 +1934,10 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de251eec69fc7c1bc3923403d18ececb929380e016afe103da75f396704f8ca2"
 dependencies = [
- "proc-macro2 1.0.9",
- "quote 1.0.3",
- "syn 1.0.17",
- "synstructure 0.12.3",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
 ]
 
 [[package]]
@@ -2042,7 +1957,7 @@ dependencies = [
 name = "zmix"
 version = "0.3.1"
 dependencies = [
- "amcl_wrapper 0.3.5",
+ "amcl_wrapper",
  "bulletproofs_amcl",
  "criterion",
  "failure",
@@ -2054,5 +1969,5 @@ dependencies = [
  "serde_json",
  "sha2",
  "ursa",
- "zeroize 1.1.0",
+ "zeroize",
 ]

--- a/libzmix/Cargo.toml
+++ b/libzmix/Cargo.toml
@@ -31,7 +31,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = { version = "0.8", default-features = false, optional = true }
 ursa = { version = "0.3", path = "../libursa", default-features = false, optional = true }
-zeroize = { version = "1.0", features = ["zeroize_derive"] }
+zeroize = { version = "1.1", features = ["zeroize_derive"] }
 
 [[bench]]
 name = "bbs_vs_ps"

--- a/libzmix/bulletproofs_amcl/Cargo.toml
+++ b/libzmix/bulletproofs_amcl/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bulletproofs_amcl"
 version = "0.2.0"
-authors = ["lovesh harchandani <lovesh.bond@gmail.com>"]
+authors = ["Hyperledger Ursa Maintainers"]
 edition = "2018"
 
 [dependencies]
@@ -16,7 +16,7 @@ criterion = "0.3"
 failure = "0.1"
 
 [dependencies.amcl_wrapper]
-version = "0.2.3"
+version = "0.3.5"
 default-features = false
 features = ["bls381"]
 

--- a/libzmix/bulletproofs_amcl/src/ipp.rs
+++ b/libzmix/bulletproofs_amcl/src/ipp.rs
@@ -259,7 +259,7 @@ impl IPP {
         bases.append(&mut R_vec.clone());
 
         let expected_P = G1Vector::from(bases)
-            .multi_scalar_mul_var_time(&exponents.into())
+            .multi_scalar_mul_var_time(exponents.as_slice())
             .unwrap();
 
         if expected_P == *P {
@@ -391,7 +391,9 @@ mod tests {
         _2.append(&mut G.clone());
         _2.append(&mut H.clone());
         _2.push(u.clone());
-        let P = G1Vector::from(_2).multi_scalar_mul_var_time(&_1).unwrap();
+        let P = G1Vector::from(_2)
+            .multi_scalar_mul_var_time(_1.as_slice())
+            .unwrap();
 
         let mut new_trans1 = Transcript::new(b"innerproduct");
         IPP::verify_ipp(

--- a/libzmix/bulletproofs_amcl/src/r1cs/gadgets/bound_check.rs
+++ b/libzmix/bulletproofs_amcl/src/r1cs/gadgets/bound_check.rs
@@ -188,7 +188,6 @@ mod tests {
 
     #[test]
     fn test_bound_check_gadget() {
-        use rand::rngs::OsRng;
         use rand::Rng;
 
         let mut rng = rand::thread_rng();

--- a/libzmix/bulletproofs_amcl/src/r1cs/gadgets/merkle_tree_hash.rs
+++ b/libzmix/bulletproofs_amcl/src/r1cs/gadgets/merkle_tree_hash.rs
@@ -104,21 +104,21 @@ pub trait Arity8MerkleTreeHashConstraints {
     ) -> Result<LinearCombination, R1CSError>;
 }
 
-pub struct MiMC_2<'a> {
+pub struct Mimc2<'a> {
     pub constants: &'a [FieldElement],
 }
 
-pub struct PoseidonHash_2<'a> {
+pub struct PoseidonHash2<'a> {
     pub params: &'a PoseidonParams,
     pub sbox: &'a SboxType,
 }
 
-pub struct PoseidonHash_4<'a> {
+pub struct PoseidonHash4<'a> {
     pub params: &'a PoseidonParams,
     pub sbox: &'a SboxType,
 }
 
-pub struct PoseidonHash_8<'a> {
+pub struct PoseidonHash8<'a> {
     pub params: &'a PoseidonParams,
     pub sbox: &'a SboxType,
 }
@@ -130,27 +130,27 @@ pub struct PoseidonHashConstraints<'a> {
     capacity_const_var: Option<Variable>,
 }
 
-impl<'a> Arity2MerkleTreeHash for MiMC_2<'a> {
+impl<'a> Arity2MerkleTreeHash for Mimc2<'a> {
     fn hash(&self, inputs: Vec<FieldElement>) -> Result<FieldElement, BulletproofError> {
         Ok(mimc(&inputs[0], &inputs[1], self.constants))
     }
 }
 
-impl<'a> Arity2MerkleTreeHash for PoseidonHash_2<'a> {
+impl<'a> Arity2MerkleTreeHash for PoseidonHash2<'a> {
     fn hash(&self, inputs: Vec<FieldElement>) -> Result<FieldElement, BulletproofError> {
         Self::is_num_inputs_correct(&inputs)?;
         Poseidon_hash_2(inputs, &self.params, &self.sbox)
     }
 }
 
-impl<'a> Arity4MerkleTreeHash for PoseidonHash_4<'a> {
+impl<'a> Arity4MerkleTreeHash for PoseidonHash4<'a> {
     fn hash(&self, inputs: Vec<FieldElement>) -> Result<FieldElement, BulletproofError> {
         Self::is_num_inputs_correct(&inputs)?;
         Poseidon_hash_4(inputs, &self.params, &self.sbox)
     }
 }
 
-impl<'a> Arity8MerkleTreeHash for PoseidonHash_8<'a> {
+impl<'a> Arity8MerkleTreeHash for PoseidonHash8<'a> {
     fn hash(&self, inputs: Vec<FieldElement>) -> Result<FieldElement, BulletproofError> {
         Self::is_num_inputs_correct(&inputs)?;
         Poseidon_hash_8(inputs, &self.params, &self.sbox)

--- a/libzmix/bulletproofs_amcl/src/r1cs/gadgets/mimc.rs
+++ b/libzmix/bulletproofs_amcl/src/r1cs/gadgets/mimc.rs
@@ -107,9 +107,7 @@ mod tests {
     use crate::r1cs::gadgets::helper_constraints::mimc::mimc;
     use crate::utils::get_generators;
     use amcl_wrapper::group_elem::GroupElement;
-    use rand::rngs::OsRng;
-    use rand::Rng;
-    use std::time::{Duration, Instant};
+    use std::time::Instant;
 
     #[test]
     fn test_mimc() {

--- a/libzmix/bulletproofs_amcl/src/r1cs/gadgets/non_zero.rs
+++ b/libzmix/bulletproofs_amcl/src/r1cs/gadgets/non_zero.rs
@@ -91,9 +91,6 @@ mod tests {
 
     #[test]
     fn test_non_zero_gadget() {
-        use rand::rngs::OsRng;
-        use rand::Rng;
-
         let mut rng = rand::thread_rng();
 
         let value = FieldElement::random();

--- a/libzmix/bulletproofs_amcl/src/r1cs/gadgets/poseidon_hash.rs
+++ b/libzmix/bulletproofs_amcl/src/r1cs/gadgets/poseidon_hash.rs
@@ -489,8 +489,6 @@ mod tests {
     };
     use crate::utils::get_generators;
     use amcl_wrapper::group_elem::GroupElement;
-    use rand::rngs::OsRng;
-    use rand::Rng;
     use std::time::Instant;
 
     fn check_hash_2(hash_params: &PoseidonParams, sbox_type: &SboxType) {

--- a/libzmix/bulletproofs_amcl/src/r1cs/gadgets/randomizer.rs
+++ b/libzmix/bulletproofs_amcl/src/r1cs/gadgets/randomizer.rs
@@ -19,8 +19,8 @@ use super::helper_constraints::poseidon::{
     PoseidonParams, Poseidon_hash_4, Poseidon_hash_4_constraints, SboxType,
 };
 use super::helper_constraints::sparse_merkle_tree_4_ary::{
-    vanilla_merkle_merkle_tree_4_verif_gadget, DBVal_4_ary, ProofNode_4_ary,
-    VanillaSparseMerkleTree_4,
+    vanilla_merkle_merkle_tree_4_verif_gadget, DbVal4ary, ProofNode4ary,
+    VanillaSparseMerkleTree4,
 };
 
 use crate::errors::R1CSError;
@@ -89,8 +89,8 @@ pub fn randomizer_gadget<CS: ConstraintSystem>(
     cs: &mut CS,
     depth: usize,
     orig_root: Variable, // original root is hidden since its correlating across several proofs
-    new_tree: &mut VanillaSparseMerkleTree_4,
-    new_db: &mut HashDb<DBVal_4_ary>,
+    new_tree: &mut VanillaSparseMerkleTree4,
+    new_db: &mut HashDb<DbVal4ary>,
     indices: Vec<FieldElement>, // For future: `indices` can be made hidden too
     orig_vals: Vec<Variable>,   // values of the original tree
     mut orig_vals_proofs: Vec<Vec<Variable>>, // merkle proofs for values of the original tree
@@ -110,7 +110,7 @@ pub fn randomizer_gadget<CS: ConstraintSystem>(
         let idx = &indices[i];
         let orig_vals_proof = &mut orig_vals_proofs[i];
 
-        let mut path_for_update = VanillaSparseMerkleTree_4::leaf_index_to_path(idx, depth);
+        let mut path_for_update = VanillaSparseMerkleTree4::leaf_index_to_path(idx, depth);
         let path_for_get = path_for_update.clone(); // Path from root to leaf
         path_for_update.reverse(); // Path from leaf to root
 
@@ -159,7 +159,7 @@ pub fn randomizer_gadget<CS: ConstraintSystem>(
         let idx = &indices[i];
         let orig_val = orig_vals[i];
 
-        let mut path = VanillaSparseMerkleTree_4::leaf_index_to_path(idx, depth);
+        let mut path = VanillaSparseMerkleTree4::leaf_index_to_path(idx, depth);
 
         let mut orig_val_lc = LinearCombination::from(orig_val);
         // Move in reverse order in path, i.e. leaf to root, updating `new_tree_modified_nodes` on nodes from leaf leading to root.
@@ -198,10 +198,10 @@ pub fn randomizer_gadget<CS: ConstraintSystem>(
 
 /// XXX ORIGINAL TREE AS ARGUMENT SEEMS ODD. BETTER PASS THE PROOF.
 pub fn gen_proof_for_randomizer(
-    orig_tree: &VanillaSparseMerkleTree_4,
-    orig_db: &HashDb<DBVal_4_ary>,
-    new_tree: &mut VanillaSparseMerkleTree_4,
-    new_db: &mut HashDb<DBVal_4_ary>,
+    orig_tree: &VanillaSparseMerkleTree4,
+    orig_db: &HashDb<DbVal4ary>,
+    new_tree: &mut VanillaSparseMerkleTree4,
+    new_db: &mut HashDb<DbVal4ary>,
     modified_indices: &[FieldElement],
     orig_vals: &[FieldElement],
     tree_depth: usize,
@@ -228,7 +228,7 @@ pub fn gen_proof_for_randomizer(
 
     //for (i, v) in modified_indices {
     for i in 0..modified_indices.len() {
-        let mut merkle_proof_vec = Vec::<ProofNode_4_ary>::new();
+        let mut merkle_proof_vec = Vec::<ProofNode4ary>::new();
         let mut merkle_proof = Some(merkle_proof_vec);
         let _v = orig_tree.get(&modified_indices[i], &mut merkle_proof, orig_db)?;
         assert_eq!(_v, orig_vals[i]);
@@ -280,8 +280,8 @@ pub fn gen_proof_for_randomizer(
 }
 
 pub fn verify_proof_for_randomizer(
-    new_tree: &mut VanillaSparseMerkleTree_4,
-    new_db: &mut HashDb<DBVal_4_ary>,
+    new_tree: &mut VanillaSparseMerkleTree4,
+    new_db: &mut HashDb<DbVal4ary>,
     modified_indices: &[FieldElement], // For future: `modified_indices` can be made hidden too
     tree_depth: usize,
     hash_params: &PoseidonParams,
@@ -349,7 +349,7 @@ mod tests {
     fn test_randomizer() {
         let width = 5;
 
-        let mut orig_db = InMemoryHashDb::<DBVal_4_ary>::new();
+        let mut orig_db = InMemoryHashDb::<DbVal4ary>::new();
 
         #[cfg(feature = "bls381")]
         let (full_b, full_e, partial_rounds) = (4, 4, 56);
@@ -380,7 +380,7 @@ mod tests {
             println!("Will modify {} entries", indices.len());
         }
 
-        let mut orig_tree = VanillaSparseMerkleTree_4::new(&hash_params, tree_depth, &mut orig_db);
+        let mut orig_tree = VanillaSparseMerkleTree4::new(&hash_params, tree_depth, &mut orig_db);
         for i in 0..data_size {
             // Next line is a temporary workaround
             let idx = FieldElement::from(i as u64);

--- a/libzmix/bulletproofs_amcl/src/r1cs/gadgets/set_membership.rs
+++ b/libzmix/bulletproofs_amcl/src/r1cs/gadgets/set_membership.rs
@@ -147,9 +147,6 @@ mod tests {
 
     #[test]
     fn test_set_membership() {
-        use rand::rngs::OsRng;
-        use rand::Rng;
-
         let mut rng = rand::thread_rng();
 
         let set = vec![

--- a/libzmix/bulletproofs_amcl/src/r1cs/gadgets/set_membership_alt.rs
+++ b/libzmix/bulletproofs_amcl/src/r1cs/gadgets/set_membership_alt.rs
@@ -218,9 +218,6 @@ mod tests {
 
     #[test]
     fn test_set_membership_alt() {
-        use rand::rngs::OsRng;
-        use rand::Rng;
-
         let mut rng = rand::thread_rng();
 
         let set: Vec<u64> = vec![2, 3, 5, 6, 8, 20, 25];

--- a/libzmix/bulletproofs_amcl/src/r1cs/gadgets/set_non_membership.rs
+++ b/libzmix/bulletproofs_amcl/src/r1cs/gadgets/set_non_membership.rs
@@ -150,9 +150,6 @@ mod tests {
 
     #[test]
     fn test_set_non_membership() {
-        use rand::rngs::OsRng;
-        use rand::Rng;
-
         let mut rng = rand::thread_rng();
 
         let set = vec![

--- a/libzmix/bulletproofs_amcl/src/r1cs/gadgets/sparse_merkle_tree_4_ary.rs
+++ b/libzmix/bulletproofs_amcl/src/r1cs/gadgets/sparse_merkle_tree_4_ary.rs
@@ -9,7 +9,7 @@ use std::time::Instant;
 use rand::{CryptoRng, Rng};
 
 use super::helper_constraints::sparse_merkle_tree_4_ary::{
-    vanilla_merkle_merkle_tree_4_verif_gadget, ProofNode_4_ary,
+    vanilla_merkle_merkle_tree_4_verif_gadget, ProofNode4ary,
 };
 use crate::r1cs::gadgets::helper_constraints::{
     get_blinding_for_merkle_tree_prover, LeafValueType,
@@ -25,7 +25,7 @@ pub fn prove_leaf_inclusion_4_ary_merkle_tree<
     leaf_index: FieldElement,
     hide_leaf: bool, // Indicates whether the leaf value is hidden from the verifier or not
     blindings: Option<Vec<FieldElement>>,
-    mut merkle_proof: Vec<ProofNode_4_ary>,
+    mut merkle_proof: Vec<ProofNode4ary>,
     root: &FieldElement,
     tree_depth: usize,
     hash_func: &mut MTHC,
@@ -125,7 +125,7 @@ pub fn gen_proof_of_leaf_inclusion_4_ary_merkle_tree<
     leaf_index: FieldElement,
     hide_leaf: bool, // Indicates whether the leaf value is hidden from the verifier or not
     blindings: Option<Vec<FieldElement>>,
-    merkle_proof: Vec<ProofNode_4_ary>,
+    merkle_proof: Vec<ProofNode4ary>,
     root: &FieldElement,
     tree_depth: usize,
     hash_func: &mut MTHC,
@@ -208,9 +208,9 @@ mod tests {
     use super::*;
     use crate::r1cs::gadgets::helper_constraints::poseidon::{PoseidonParams, SboxType};
     use crate::r1cs::gadgets::helper_constraints::sparse_merkle_tree_4_ary::{
-        DBVal_4_ary, VanillaSparseMerkleTree_4,
+        DbVal4ary, VanillaSparseMerkleTree4,
     };
-    use crate::r1cs::gadgets::merkle_tree_hash::{PoseidonHashConstraints, PoseidonHash_4};
+    use crate::r1cs::gadgets::merkle_tree_hash::{PoseidonHash4, PoseidonHashConstraints};
     use crate::utils::get_generators;
     use crate::utils::hash_db::InMemoryHashDb;
     use amcl_wrapper::group_elem::GroupElement;
@@ -221,7 +221,7 @@ mod tests {
 
         let width = 5;
 
-        let mut db = InMemoryHashDb::<DBVal_4_ary>::new();
+        let mut db = InMemoryHashDb::<DbVal4ary>::new();
 
         #[cfg(feature = "bls381")]
         let (full_b, full_e, partial_rounds) = (4, 4, 56);
@@ -235,16 +235,16 @@ mod tests {
         #[cfg(feature = "ed25519")]
         let (full_b, full_e, partial_rounds) = (4, 4, 56);
 
-        let total_rounds = full_b + partial_rounds + full_e;
+        // let total_rounds = full_b + partial_rounds + full_e;
         let hash_params = PoseidonParams::new(width, full_b, full_e, partial_rounds).unwrap();
         let tree_depth = 12;
         let sbox = &SboxType::Quint;
 
-        let hash_func = PoseidonHash_4 {
+        let hash_func = PoseidonHash4 {
             params: &hash_params,
             sbox,
         };
-        let mut tree = VanillaSparseMerkleTree_4::new(&hash_func, tree_depth, &mut db).unwrap();
+        let mut tree = VanillaSparseMerkleTree4::new(&hash_func, tree_depth, &mut db).unwrap();
 
         for i in 1..=10 {
             let s = FieldElement::from(i as u32);
@@ -259,7 +259,7 @@ mod tests {
         let h = G1::from_msg_hash("h".as_bytes());
 
         for i in vec![3u32, 4u32, 7u32, 8u32, 9u32] {
-            let mut merkle_proof_vec = Vec::<ProofNode_4_ary>::new();
+            let mut merkle_proof_vec = Vec::<ProofNode4ary>::new();
             let mut merkle_proof = Some(merkle_proof_vec);
             let k = FieldElement::from(i);
             assert_eq!(k, tree.get(&k, &mut merkle_proof, &db).unwrap());

--- a/libzmix/bulletproofs_amcl/src/r1cs/gadgets/sparse_merkle_tree_8_ary.rs
+++ b/libzmix/bulletproofs_amcl/src/r1cs/gadgets/sparse_merkle_tree_8_ary.rs
@@ -9,7 +9,7 @@ use std::time::Instant;
 use rand::{CryptoRng, Rng};
 
 use super::helper_constraints::sparse_merkle_tree_8_ary::{
-    vanilla_merkle_merkle_tree_8_verif_gadget, ProofNode_8_ary,
+    vanilla_merkle_merkle_tree_8_verif_gadget, ProofNode8ary,
 };
 use crate::r1cs::gadgets::helper_constraints::{
     get_blinding_for_merkle_tree_prover, LeafValueType,
@@ -25,7 +25,7 @@ pub fn prove_leaf_inclusion_8_ary_merkle_tree<
     leaf_index: FieldElement,
     hide_leaf: bool, // Indicates whether the leaf value is hidden from the verifier or not
     blindings: Option<Vec<FieldElement>>,
-    mut merkle_proof: Vec<ProofNode_8_ary>,
+    mut merkle_proof: Vec<ProofNode8ary>,
     root: &FieldElement,
     tree_depth: usize,
     hash_func: &mut MTHC,
@@ -127,7 +127,7 @@ pub fn gen_proof_of_leaf_inclusion_8_ary_merkle_tree<
     leaf_index: FieldElement,
     hide_leaf: bool, // Indicates whether the leaf value is hidden from the verifier or not
     randomness: Option<Vec<FieldElement>>,
-    merkle_proof: Vec<ProofNode_8_ary>,
+    merkle_proof: Vec<ProofNode8ary>,
     root: &FieldElement,
     tree_depth: usize,
     hash_func: &mut MTHC,
@@ -208,9 +208,9 @@ mod tests {
         PoseidonParams, SboxType, CAP_CONST_W_9,
     };
     use crate::r1cs::gadgets::helper_constraints::sparse_merkle_tree_8_ary::{
-        DBVal_8_ary, VanillaSparseMerkleTree_8,
+        DbVal8ary, VanillaSparseMerkleTree8,
     };
-    use crate::r1cs::gadgets::merkle_tree_hash::{PoseidonHashConstraints, PoseidonHash_8};
+    use crate::r1cs::gadgets::merkle_tree_hash::{PoseidonHash8, PoseidonHashConstraints};
     use crate::utils::get_generators;
     use crate::utils::hash_db::InMemoryHashDb;
     use amcl_wrapper::group_elem::GroupElement;
@@ -219,7 +219,7 @@ mod tests {
     fn test_VSMT_8_Verif() {
         let width = 9;
 
-        let mut db = InMemoryHashDb::<DBVal_8_ary>::new();
+        let mut db = InMemoryHashDb::<DbVal8ary>::new();
 
         #[cfg(feature = "bls381")]
         let (full_b, full_e, partial_rounds) = (4, 4, 56);
@@ -233,23 +233,23 @@ mod tests {
         #[cfg(feature = "ed25519")]
         let (full_b, full_e, partial_rounds) = (4, 4, 56);
 
-        let total_rounds = full_b + partial_rounds + full_e;
+        // let total_rounds = full_b + partial_rounds + full_e;
         let hash_params = PoseidonParams::new(width, full_b, full_e, partial_rounds).unwrap();
         let tree_depth = 8;
         let sbox = &SboxType::Quint;
 
-        let hash_func = PoseidonHash_8 {
+        let hash_func = PoseidonHash8 {
             params: &hash_params,
             sbox,
         };
-        let mut tree = VanillaSparseMerkleTree_8::new(&hash_func, tree_depth, &mut db).unwrap();
+        let mut tree = VanillaSparseMerkleTree8::new(&hash_func, tree_depth, &mut db).unwrap();
 
         for i in 1..=10 {
             let s = FieldElement::from(i as u32);
             tree.update(&s, s.clone(), &mut db).unwrap();
         }
 
-        let mut merkle_proof_vec = Vec::<ProofNode_8_ary>::new();
+        let mut merkle_proof_vec = Vec::<ProofNode8ary>::new();
         let mut merkle_proof = Some(merkle_proof_vec);
         let k = FieldElement::from(9u32);
         assert_eq!(k, tree.get(&k, &mut merkle_proof, &db).unwrap());

--- a/libzmix/bulletproofs_amcl/src/r1cs/prover.rs
+++ b/libzmix/bulletproofs_amcl/src/r1cs/prover.rs
@@ -190,101 +190,101 @@ impl<'a, 'b> Prover<'a, 'b> {
     }
 
     // This is used only for debugging
-    #[cfg(test)]
-    fn get_weight_matrices(
-        &self,
-    ) -> (
-        Vec<FieldElementVector>,
-        Vec<FieldElementVector>,
-        Vec<FieldElementVector>,
-        Vec<FieldElementVector>,
-    ) {
-        let n = self.a_L.len();
-        let m = self.v.len();
-        let q = self.constraints.len();
-        let mut WL = vec![FieldElementVector::new(n); q];
-        let mut WR = vec![FieldElementVector::new(n); q];
-        let mut WO = vec![FieldElementVector::new(n); q];
-        let mut WV = vec![FieldElementVector::new(m); q];
-
-        for (r, lc) in self.constraints.iter().enumerate() {
-            for (var, coeff) in &lc.terms {
-                match var {
-                    Variable::MultiplierLeft(i) => {
-                        let (i, coeff) = (*i, coeff.clone());
-                        WL[r][i] = coeff;
-                    }
-                    Variable::MultiplierRight(i) => {
-                        let (i, coeff) = (*i, coeff.clone());
-                        WR[r][i] = coeff;
-                    }
-                    Variable::MultiplierOutput(i) => {
-                        let (i, coeff) = (*i, coeff.clone());
-                        WO[r][i] = coeff;
-                    }
-                    Variable::Committed(i) => {
-                        let (i, coeff) = (*i, coeff.clone());
-                        WV[r][i] = coeff;
-                    }
-                    Variable::One() => {
-                        // The prover doesn't need to handle constant terms
-                    }
-                }
-            }
-        }
-
-        (WL, WR, WO, WV)
-    }
+    // #[cfg(test)]
+    // fn get_weight_matrices(
+    //     &self,
+    // ) -> (
+    //     Vec<FieldElementVector>,
+    //     Vec<FieldElementVector>,
+    //     Vec<FieldElementVector>,
+    //     Vec<FieldElementVector>,
+    // ) {
+    //     let n = self.a_L.len();
+    //     let m = self.v.len();
+    //     let q = self.constraints.len();
+    //     let mut WL = vec![FieldElementVector::new(n); q];
+    //     let mut WR = vec![FieldElementVector::new(n); q];
+    //     let mut WO = vec![FieldElementVector::new(n); q];
+    //     let mut WV = vec![FieldElementVector::new(m); q];
+    //
+    //     for (r, lc) in self.constraints.iter().enumerate() {
+    //         for (var, coeff) in &lc.terms {
+    //             match var {
+    //                 Variable::MultiplierLeft(i) => {
+    //                     let (i, coeff) = (*i, coeff.clone());
+    //                     WL[r][i] = coeff;
+    //                 }
+    //                 Variable::MultiplierRight(i) => {
+    //                     let (i, coeff) = (*i, coeff.clone());
+    //                     WR[r][i] = coeff;
+    //                 }
+    //                 Variable::MultiplierOutput(i) => {
+    //                     let (i, coeff) = (*i, coeff.clone());
+    //                     WO[r][i] = coeff;
+    //                 }
+    //                 Variable::Committed(i) => {
+    //                     let (i, coeff) = (*i, coeff.clone());
+    //                     WV[r][i] = coeff;
+    //                 }
+    //                 Variable::One() => {
+    //                     // The prover doesn't need to handle constant terms
+    //                 }
+    //             }
+    //         }
+    //     }
+    //
+    //     (WL, WR, WO, WV)
+    // }
 
     // This is used only for debugging
-    #[cfg(test)]
-    fn flattened_constraints_elaborated(
-        &self,
-        z: &FieldElement,
-    ) -> (
-        FieldElementVector,
-        FieldElementVector,
-        FieldElementVector,
-        FieldElementVector,
-    ) {
-        use amcl_wrapper::field_elem::multiply_row_vector_with_matrix;
-
-        let (WL, WR, WO, WV) = self.get_weight_matrices();
-
-        /*println!("Left Weight matrix");
-        util::print_2d_matrix(&WL);
-        println!("Right Weight matrix");
-        util::print_2d_matrix(&WR);
-        println!("Out Weight matrix");
-        util::print_2d_matrix(&WO);
-        println!("Comm Weight matrix");
-        util::print_2d_matrix(&WV);*/
-
-        let q = self.constraints.len();
-        let z_exp: FieldElementVector = FieldElementVector::new_vandermonde_vector(z, q + 1)
-            .into_iter()
-            .skip(1)
-            .collect::<Vec<_>>()
-            .into();
-
-        let minus_z_exp: FieldElementVector = z_exp
-            .iter()
-            .map(|e| (*e).negation())
-            .collect::<Vec<_>>()
-            .into();
-        let wL = multiply_row_vector_with_matrix(&z_exp, &WL).unwrap();
-        let wR = multiply_row_vector_with_matrix(&z_exp, &WR).unwrap();
-        let wO = multiply_row_vector_with_matrix(&z_exp, &WO).unwrap();
-        let wV = multiply_row_vector_with_matrix(&minus_z_exp, &WV).unwrap();
-
-        /*println!("Flattened weights");
-        util::print_vector(&wL);
-        util::print_vector(&wR);
-        util::print_vector(&wO);
-        util::print_vector(&wV);*/
-
-        (wL, wR, wO, wV)
-    }
+    // #[cfg(test)]
+    // fn flattened_constraints_elaborated(
+    //     &self,
+    //     z: &FieldElement,
+    // ) -> (
+    //     FieldElementVector,
+    //     FieldElementVector,
+    //     FieldElementVector,
+    //     FieldElementVector,
+    // ) {
+    //     use amcl_wrapper::field_elem::multiply_row_vector_with_matrix;
+    //
+    //     let (WL, WR, WO, WV) = self.get_weight_matrices();
+    //
+    //     /*println!("Left Weight matrix");
+    //     util::print_2d_matrix(&WL);
+    //     println!("Right Weight matrix");
+    //     util::print_2d_matrix(&WR);
+    //     println!("Out Weight matrix");
+    //     util::print_2d_matrix(&WO);
+    //     println!("Comm Weight matrix");
+    //     util::print_2d_matrix(&WV);*/
+    //
+    //     let q = self.constraints.len();
+    //     let z_exp: FieldElementVector = FieldElementVector::new_vandermonde_vector(z, q + 1)
+    //         .into_iter()
+    //         .skip(1)
+    //         .collect::<Vec<_>>()
+    //         .into();
+    //
+    //     let minus_z_exp: FieldElementVector = z_exp
+    //         .iter()
+    //         .map(|e| (*e).negation())
+    //         .collect::<Vec<_>>()
+    //         .into();
+    //     let wL = multiply_row_vector_with_matrix(&z_exp, &WL).unwrap();
+    //     let wR = multiply_row_vector_with_matrix(&z_exp, &WR).unwrap();
+    //     let wO = multiply_row_vector_with_matrix(&z_exp, &WO).unwrap();
+    //     let wV = multiply_row_vector_with_matrix(&minus_z_exp, &WV).unwrap();
+    //
+    //     /*println!("Flattened weights");
+    //     util::print_vector(&wL);
+    //     util::print_vector(&wR);
+    //     util::print_vector(&wO);
+    //     util::print_vector(&wV);*/
+    //
+    //     (wL, wR, wO, wV)
+    // }
 
     fn eval(&self, lc: &LinearCombination) -> FieldElement {
         lc.terms
@@ -366,7 +366,8 @@ impl<'a, 'b> Prover<'a, 'b> {
         .unwrap();
 
         // A_O = <a_O, G> + o_blinding * B_blinding
-        let A_O1 = G_n1.inner_product_const_time(&self.a_O).unwrap() + self.h * &o_blinding1;
+        let A_O1 =
+            G_n1.inner_product_const_time(self.a_O.as_slice()).unwrap() + self.h * &o_blinding1;
 
         // S = <s_L, G> + <s_R, H> + s_blinding * B_blinding
         let S1 = commit_to_field_element_vectors(&G_n1, &H_n1, &self.h, &s_L1, &s_R1, &s_blinding1)
@@ -436,7 +437,7 @@ impl<'a, 'b> Prover<'a, 'b> {
                 )
                 .unwrap(),
                 // A_O = <a_O, G> + o_blinding * B_blinding
-                G_n2.inner_product_const_time(&a_O_n2).unwrap() + self.h * &o_blinding2,
+                G_n2.inner_product_const_time(a_O_n2.as_slice()).unwrap() + self.h * &o_blinding2,
                 // S = <s_L, G> + <s_R, H> + s_blinding * B_blinding
                 commit_to_field_element_vectors(&G_n2, &H_n2, self.h, &s_L2, &s_R2, &s_blinding2)
                     .unwrap(),

--- a/libzmix/bulletproofs_amcl/src/r1cs/verifier.rs
+++ b/libzmix/bulletproofs_amcl/src/r1cs/verifier.rs
@@ -198,6 +198,7 @@ impl<'a> Verifier<'a> {
         (wL, wR, wO, wV, wc)
     }
 
+    // Only used for debugging purposes
     // #[cfg(test)]
     // fn get_weight_matrices(
     //     &self,

--- a/libzmix/bulletproofs_amcl/src/r1cs/verifier.rs
+++ b/libzmix/bulletproofs_amcl/src/r1cs/verifier.rs
@@ -198,53 +198,53 @@ impl<'a> Verifier<'a> {
         (wL, wR, wO, wV, wc)
     }
 
-    #[cfg(test)]
-    fn get_weight_matrices(
-        &self,
-    ) -> (
-        Vec<FieldElementVector>,
-        Vec<FieldElementVector>,
-        Vec<FieldElementVector>,
-        Vec<FieldElementVector>,
-        FieldElement,
-    ) {
-        let n = self.num_vars;
-        let m = self.V.len();
-        let q = self.constraints.len();
-        let mut WL = vec![FieldElementVector::new(n); q];
-        let mut WR = vec![FieldElementVector::new(n); q];
-        let mut WO = vec![FieldElementVector::new(n); q];
-        let mut WV = vec![FieldElementVector::new(m); q];
-        let mut wc = FieldElement::zero();
-
-        for (r, lc) in self.constraints.iter().enumerate() {
-            for (var, coeff) in &lc.terms {
-                match var {
-                    Variable::MultiplierLeft(i) => {
-                        let (i, coeff) = (*i, coeff.clone());
-                        WL[r][i] = coeff;
-                    }
-                    Variable::MultiplierRight(i) => {
-                        let (i, coeff) = (*i, coeff.clone());
-                        WR[r][i] = coeff;
-                    }
-                    Variable::MultiplierOutput(i) => {
-                        let (i, coeff) = (*i, coeff.clone());
-                        WO[r][i] = coeff;
-                    }
-                    Variable::Committed(i) => {
-                        let (i, coeff) = (*i, coeff.clone());
-                        WV[r][i] = coeff;
-                    }
-                    Variable::One() => {
-                        wc -= coeff;
-                    }
-                }
-            }
-        }
-
-        (WL, WR, WO, WV, wc)
-    }
+    // #[cfg(test)]
+    // fn get_weight_matrices(
+    //     &self,
+    // ) -> (
+    //     Vec<FieldElementVector>,
+    //     Vec<FieldElementVector>,
+    //     Vec<FieldElementVector>,
+    //     Vec<FieldElementVector>,
+    //     FieldElement,
+    // ) {
+    //     let n = self.num_vars;
+    //     let m = self.V.len();
+    //     let q = self.constraints.len();
+    //     let mut WL = vec![FieldElementVector::new(n); q];
+    //     let mut WR = vec![FieldElementVector::new(n); q];
+    //     let mut WO = vec![FieldElementVector::new(n); q];
+    //     let mut WV = vec![FieldElementVector::new(m); q];
+    //     let mut wc = FieldElement::zero();
+    //
+    //     for (r, lc) in self.constraints.iter().enumerate() {
+    //         for (var, coeff) in &lc.terms {
+    //             match var {
+    //                 Variable::MultiplierLeft(i) => {
+    //                     let (i, coeff) = (*i, coeff.clone());
+    //                     WL[r][i] = coeff;
+    //                 }
+    //                 Variable::MultiplierRight(i) => {
+    //                     let (i, coeff) = (*i, coeff.clone());
+    //                     WR[r][i] = coeff;
+    //                 }
+    //                 Variable::MultiplierOutput(i) => {
+    //                     let (i, coeff) = (*i, coeff.clone());
+    //                     WO[r][i] = coeff;
+    //                 }
+    //                 Variable::Committed(i) => {
+    //                     let (i, coeff) = (*i, coeff.clone());
+    //                     WV[r][i] = coeff;
+    //                 }
+    //                 Variable::One() => {
+    //                     wc -= coeff;
+    //                 }
+    //             }
+    //         }
+    //     }
+    //
+    //     (WL, WR, WO, WV, wc)
+    // }
 
     /// Calls all remembered callbacks with an API that
     /// allows generating challenge scalars.

--- a/libzmix/bulletproofs_amcl/tests/multiple_constraint_systems.rs
+++ b/libzmix/bulletproofs_amcl/tests/multiple_constraint_systems.rs
@@ -3,7 +3,7 @@ mod tests {
     extern crate merlin;
     use bulletproofs_amcl as bulletproofs;
 
-    use bulletproofs::r1cs::{ConstraintSystem, LinearCombination, Prover, Variable, Verifier};
+    use bulletproofs::r1cs::{Prover, Verifier};
 
     use bulletproofs::r1cs::gadgets::bound_check::{prove_bounded_num, verify_bounded_num};
 
@@ -18,7 +18,6 @@ mod tests {
         prove_set_non_membership, verify_set_non_membership,
     };
     use merlin::Transcript;
-    use rand::rngs::OsRng;
     use rand::Rng;
 
     #[test]
@@ -40,8 +39,8 @@ mod tests {
         let max_3 = 1090;
         let v_3 = rng.gen_range(min_3, max_3);
 
-        let G: G1Vector = get_generators("G", 512).into();
-        let H: G1Vector = get_generators("H", 512).into();
+        let big_g: G1Vector = get_generators("G", 512).into();
+        let big_h: G1Vector = get_generators("H", 512).into();
         let g = G1::from_msg_hash("g".as_bytes());
         let h = G1::from_msg_hash("h".as_bytes());
 
@@ -83,7 +82,7 @@ mod tests {
         )
         .unwrap();
 
-        let proof = prover.prove(&G, &H).unwrap();
+        let proof = prover.prove(&big_g, &big_h).unwrap();
 
         let mut verifier_transcript = Transcript::new(transcript_label);
         let mut verifier = Verifier::new(&mut verifier_transcript);
@@ -92,7 +91,7 @@ mod tests {
         verify_bounded_num(min_2, max_2, max_bits_in_val, comms_2, &mut verifier).unwrap();
         verify_bounded_num(min_3, max_3, max_bits_in_val, comms_3, &mut verifier).unwrap();
 
-        assert!(verifier.verify(&proof, &g, &h, &G, &H).is_ok())
+        assert!(verifier.verify(&proof, &g, &h, &big_g, &big_h).is_ok())
     }
 
     #[test]
@@ -119,8 +118,8 @@ mod tests {
         let present_value = FieldElement::from(125);
         let absent_value = FieldElement::from(10);
 
-        let G: G1Vector = get_generators("G", 256).into();
-        let H: G1Vector = get_generators("H", 256).into();
+        let big_g: G1Vector = get_generators("G", 256).into();
+        let big_h: G1Vector = get_generators("H", 256).into();
         let g = G1::from_msg_hash("g".as_bytes());
         let h = G1::from_msg_hash("h".as_bytes());
 
@@ -158,7 +157,7 @@ mod tests {
         )
         .unwrap();
 
-        let proof = prover.prove(&G, &H).unwrap();
+        let proof = prover.prove(&big_g, &big_h).unwrap();
 
         let mut verifier_transcript = Transcript::new(transcript_label);
         let mut verifier = Verifier::new(&mut verifier_transcript);
@@ -169,6 +168,6 @@ mod tests {
 
         verify_set_non_membership(set.as_slice(), comms_3, &mut verifier).unwrap();
 
-        assert!(verifier.verify(&proof, &g, &h, &G, &H).is_ok())
+        assert!(verifier.verify(&proof, &g, &h, &big_g, &big_h).is_ok())
     }
 }

--- a/libzmix/bulletproofs_amcl/tests/r1cs.rs
+++ b/libzmix/bulletproofs_amcl/tests/r1cs.rs
@@ -15,8 +15,8 @@ mod tests {
     #[test]
     fn test_2_factors_r1cs() {
         // Prove knowledge of `p` and `q` such that given an `r`, `p * q = r`
-        let G: G1Vector = get_generators("G", 8).into();
-        let H: G1Vector = get_generators("H", 8).into();
+        let big_g: G1Vector = get_generators("G", 8).into();
+        let big_h: G1Vector = get_generators("H", 8).into();
         let g = G1::from_msg_hash("g".as_bytes());
         let h = G1::from_msg_hash("h".as_bytes());
 
@@ -48,7 +48,7 @@ mod tests {
                 comms.push(com_q);
             }
 
-            let proof = prover.prove(&G, &H).unwrap();
+            let proof = prover.prove(&big_g, &big_h).unwrap();
 
             (proof, comms)
         };
@@ -65,14 +65,14 @@ mod tests {
             verifier.constrain(o - lc);
         }
 
-        assert!(verifier.verify(&proof, &g, &h, &G, &H).is_ok());
+        assert!(verifier.verify(&proof, &g, &h, &big_g, &big_h).is_ok());
     }
 
     #[test]
     fn test_factor_r1cs() {
         // Prove knowledge of `p`, `q`, `r` and `s` such that given an `s`, `p * q * r = s`
-        let G: G1Vector = get_generators("G", 8).into();
-        let H: G1Vector = get_generators("H", 8).into();
+        let big_g: G1Vector = get_generators("G", 8).into();
+        let big_h: G1Vector = get_generators("H", 8).into();
         let g = G1::from_msg_hash("g".as_bytes());
         let h = G1::from_msg_hash("h".as_bytes());
 
@@ -109,7 +109,7 @@ mod tests {
                 comms.push(com_r);
             }
 
-            let proof = prover.prove(&G, &H).unwrap();
+            let proof = prover.prove(&big_g, &big_h).unwrap();
 
             (proof, comms)
         };
@@ -128,6 +128,6 @@ mod tests {
             verifier.constrain(o2 - lc);
         }
 
-        assert!(verifier.verify(&proof, &g, &h, &G, &H).is_ok());
+        assert!(verifier.verify(&proof, &g, &h, &big_g, &big_h).is_ok());
     }
 }

--- a/libzmix/src/lib.rs
+++ b/libzmix/src/lib.rs
@@ -1,6 +1,6 @@
 //#[macro_use]
 //extern crate lazy_static;
-extern crate amcl_wrapper;
+pub extern crate amcl_wrapper;
 extern crate failure;
 #[macro_use]
 extern crate serde;

--- a/libzmix/src/signatures/bbs/pok_sig.rs
+++ b/libzmix/src/signatures/bbs/pok_sig.rs
@@ -379,7 +379,7 @@ mod tests {
     }
 
     #[test]
-    fn test_PoK_multiple_sigs_with_same_msg() {
+    fn test_pok_multiple_sigs_with_same_msg() {
         // Prove knowledge of multiple signatures and the equality of a specific message under both signatures.
         // Knowledge of 2 signatures and their corresponding messages is being proven.
         // 2nd message in the 1st signature and 5th message in the 2nd signature are to be proven equal without revealing them

--- a/libzmix/tests/ps_sig_complete_scenario.rs
+++ b/libzmix/tests/ps_sig_complete_scenario.rs
@@ -10,7 +10,7 @@ use zmix::signatures::ps::keys::Params;
 use zmix::signatures::ps::prelude::*;
 
 #[test]
-fn test_PS_sig_and_proof_of_knowledge_of_sig() {
+fn test_ps_sig_and_proof_of_knowledge_of_sig() {
     // For PS signature
     // A complete scenario showing requesting of signature, creation of signature, verification of signature,
     // proving knowledge of signature and verifying this proof of knowledge.


### PR DESCRIPTION
This updates bulletproofs to use amcl_wrapper 0.3.5 and removes lots of warnings