### PR TITLE
Add method to derive x25519 from an ed25519 private key

### DIFF
--- a/libursa/src/signatures/ed25519.rs
+++ b/libursa/src/signatures/ed25519.rs
@@ -56,8 +56,8 @@ impl Ed25519Sha512 {
             return Err(CryptoError::ParseError(format!("Invalid secret provided")));
         }
         let mut private = vec![0u8; 64];
-        private[0..32].copy_from_slice(seed);
-        let sk = SK::from_bytes(&private[..32]).unwrap();
+        private[..32].copy_from_slice(&seed[..32]);
+        let sk = SK::from_bytes(&seed[..32]).unwrap();
         let pk = PK::from(&sk).to_bytes().to_vec();
         private[32..].copy_from_slice(pk.as_ref());
         Ok((PublicKey(pk), PrivateKey(private)))

--- a/libursa/src/signatures/ed25519.rs
+++ b/libursa/src/signatures/ed25519.rs
@@ -1,7 +1,7 @@
 pub const ALGORITHM_NAME: &str = "ED25519_SHA2_512";
 
 use super::{KeyGenOption, SignatureScheme};
-use ed25519_dalek::{Keypair, PublicKey as PK, Signature};
+use ed25519_dalek::{Keypair, PublicKey as PK, SecretKey as SK, Signature};
 pub use ed25519_dalek::{
     EXPANDED_SECRET_KEY_LENGTH as PRIVATE_KEY_SIZE, PUBLIC_KEY_LENGTH as PUBLIC_KEY_SIZE,
     SIGNATURE_LENGTH as SIGNATURE_SIZE,
@@ -33,6 +33,34 @@ impl Ed25519Sha512 {
                 "Invalid public key provided. Cannot convert to key exchange key"
             ))),
         }
+    }
+
+    pub fn sign_key_to_key_exchange(sk: &PrivateKey) -> Result<PrivateKey, CryptoError> {
+        // Length is normally 64 but we only need the secret from the first half
+        if sk.len() < 32 {
+            return Err(CryptoError::ParseError(format!(
+                "Invalid private key provided"
+            )));
+        }
+        // hash secret
+        let hash = sha2::Sha512::digest(&sk[..32]);
+        let mut output = [0u8; 32];
+        output.copy_from_slice(&hash[..32]);
+        // clamp result
+        let secret = x25519_dalek::StaticSecret::from(output);
+        Ok(PrivateKey(secret.to_bytes().to_vec()))
+    }
+
+    pub fn keypair_from_secret(seed: &[u8]) -> Result<(PublicKey, PrivateKey), CryptoError> {
+        if seed.len() < 32 {
+            return Err(CryptoError::ParseError(format!("Invalid secret provided")));
+        }
+        let mut private = vec![0u8; 64];
+        private[0..32].copy_from_slice(seed);
+        let sk = SK::from_bytes(&private[..32]).unwrap();
+        let pk = PK::from(&sk).to_bytes().to_vec();
+        private[32..].copy_from_slice(pk.as_ref());
+        Ok((PublicKey(pk), PrivateKey(private)))
     }
 }
 
@@ -106,7 +134,11 @@ mod test {
     const MESSAGE_1: &[u8] = b"This is a dummy message for use with tests";
     const SIGNATURE_1: &str = "451b5b8e8725321541954997781de51f4142e4a56bab68d24f6a6b92615de5eefb74134138315859a32c7cf5fe5a488bc545e2e08e5eedfd1fb10188d532d808";
     const PRIVATE_KEY: &str = "1c1179a560d092b90458fe6ab8291215a427fcd6b3927cb240701778ef55201927c96646f2d4632d4fc241f84cbc427fbc3ecaa95becba55088d6c7b81fc5bbf";
+    const PRIVATE_KEY_X25519: &str =
+        "08e7286c232ec71b37918533ea0229bf0c75d3db4731df1c5c03c45bc909475f";
     const PUBLIC_KEY: &str = "27c96646f2d4632d4fc241f84cbc427fbc3ecaa95becba55088d6c7b81fc5bbf";
+    const PUBLIC_KEY_X25519: &str =
+        "9b4260484c889158c128796103dc8d8b883977f2ef7efb0facb12b6ca9b2ae3d";
 
     #[test]
     #[ignore]
@@ -202,11 +234,37 @@ mod test {
 
     #[cfg(any(feature = "x25519", feature = "x25519_asm"))]
     #[test]
-    fn ed25519_to_x25519() {
+    fn ed25519_to_x25519_default() {
         let scheme = Ed25519Sha512::new();
         let (p, _) = scheme.keypair(None).unwrap();
 
         let res = Ed25519Sha512::ver_key_to_key_exchange(&p);
         assert!(res.is_ok());
+    }
+
+    #[cfg(any(feature = "x25519", feature = "x25519_asm"))]
+    #[test]
+    fn ed25519_to_x25519_verify() {
+        let sk = PrivateKey(hex::decode(PRIVATE_KEY).unwrap());
+        let pk = PublicKey(hex::decode(PUBLIC_KEY).unwrap());
+        let scheme = Ed25519Sha512::new();
+
+        let x_pk = Ed25519Sha512::ver_key_to_key_exchange(&pk).unwrap();
+        assert_eq!(hex::encode(&x_pk), PUBLIC_KEY_X25519);
+
+        let x_sk = Ed25519Sha512::sign_key_to_key_exchange(&sk).unwrap();
+        assert_eq!(hex::encode(&x_sk), PRIVATE_KEY_X25519);
+    }
+
+    #[cfg(any(feature = "x25519", feature = "x25519_asm"))]
+    #[test]
+    fn nacl_derive_from_seed() {
+        let seed = b"000000000000000000000000Trustee1";
+        let test_sk = hex::decode("3030303030303030303030303030303030303030303030305472757374656531e33aaf381fffa6109ad591fdc38717945f8fabf7abf02086ae401c63e9913097").unwrap();
+        let test_pk = &test_sk[32..];
+
+        let (pk, sk) = Ed25519Sha512::keypair_from_secret(seed).unwrap();
+        assert_eq!(pk.0, test_pk);
+        assert_eq!(sk.0, test_sk);
     }
 }


### PR DESCRIPTION
This method is compatible with libsodium's `crypto_sign_ed25519_sk_to_curve25519`.

This PR also adds `Ed25519Sha519::keypair_from_secret` which is compatible with libsodium's `crypto_sign_seed_keypair`. @mikelodder7  I didn't add this as a separate KeyGenOption as it didn't seem to be generally applicable, but I'll let you be the judge.