### PR TITLE
Implement compressed form

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee5cca1ddc8b9dceb55b7f1272a9d1e643d73006f350a20ab4926d24e33f0f0d"
 
 [[package]]
+name = "amcl-milagro"
+version = "3.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7f1be21d1876ce01fe62e2984fd4617fccc251f17d25098e869fd83f71e770"
+
+[[package]]
 name = "amcl_wrapper"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,6 +95,27 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "sha3",
+ "subtle-encoding",
+ "zeroize",
+]
+
+[[package]]
+name = "amcl_wrapper_ml"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42a488f50de1a3614f6ee9684c973b70634a03c4873da0141c0e53632677410"
+dependencies = [
+ "amcl-milagro",
+ "arrayref",
+ "byteorder",
+ "hash2curve",
+ "lazy_static",
+ "rand 0.7.3",
+ "rayon",
+ "serde",
+ "serde_json",
+ "sha2",
  "sha3",
  "subtle-encoding",
  "zeroize",
@@ -146,9 +173,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de8aba10a69c8e8d7622c5710229485ec32e9d55fdad160ea559c086fdcd118"
+checksum = "78848718ee1255a2485d1309ad9cdecfc2e7d0362dd11c6829364c6b35ae1bc7"
 dependencies = [
  "cc",
  "libc",
@@ -156,9 +183,9 @@ dependencies = [
 
 [[package]]
 name = "bbs"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
- "amcl_wrapper",
+ "amcl_wrapper_ml",
  "arrayref",
  "failure",
  "hash2curve",
@@ -779,13 +806,14 @@ checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "hash2curve"
-version = "0.0.4"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5a05e2e152ddcce934b90dfff46c68b1bc466a6481b0808d867defa14ec57d4"
+checksum = "e2a6bd19dc0e3fd7a8c1082a5ae48c33f3ef1492c4780f541e1686c6e1e174d8"
 dependencies = [
+ "amcl-milagro",
+ "arrayref",
  "digest",
  "failure",
- "miracl_amcl",
  "sha2",
  "subtle 2.2.2",
  "subtle-encoding",
@@ -1387,9 +1415,9 @@ checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 
 [[package]]
 name = "regex"
-version = "1.3.6"
+version = "1.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f6946991529684867e47d86474e3a6d0c0ab9b82d5821e314b1ede31fa3a4b3"
+checksum = "a6020f034922e3194c711b82a627453881bc4682166cabb07134a10c26ba7692"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1683,12 +1711,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
- "redox_syscall",
  "winapi",
 ]
 
@@ -1914,9 +1941,9 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa515c5163a99cc82bab70fd3bfdd36d827be85de63737b40fcef2ce084a436e"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
 dependencies = [
  "winapi",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,9 @@ dependencies = [
  "arrayref",
  "failure",
  "hash2curve",
+ "hex",
+ "hkdf",
+ "rand 0.7.3",
  "rayon",
  "serde",
  "sha2",
@@ -833,6 +836,16 @@ name = "hex"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
+
+[[package]]
+name = "hkdf"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fa08a006102488bd9cd5b8013aabe84955cf5ae22e304c2caf655b633aefae3"
+dependencies = [
+ "digest",
+ "hmac",
+]
 
 [[package]]
 name = "hmac"

--- a/libzmix/Cargo.toml
+++ b/libzmix/Cargo.toml
@@ -22,7 +22,7 @@ PS_Signature_G1 = []
 [dependencies]
 arrayref = "0.3.6"
 bulletproofs_amcl = { version = "0.2.0", path = "./bulletproofs_amcl" }
-bbs =  { version = "0.2.0", path = "./bbs", optional = true }
+bbs =  { version = "0.3.0", path = "./bbs", optional = true }
 criterion = "0.3"
 failure = "0.1"
 lazy_static = "1.4"

--- a/libzmix/bbs/Cargo.toml
+++ b/libzmix/bbs/Cargo.toml
@@ -7,16 +7,16 @@ license = "Apache-2.0"
 name = "bbs"
 readme = "README.md"
 repository = "https://github.com/hyperledger/ursa"
-version = "0.2.0"
+version = "0.3.0"
 
 [badges]
 maintenance = { status = "active" }
 
 [dependencies]
-amcl_wrapper = { version = "0.3", default-features = false, features = ["bls381"] }
+amcl_wrapper = { version = "0.5", default-features = false, features = ["bls381"], package = "amcl_wrapper_ml" }
 arrayref = "0.3"
 failure = "0.1"
-hash2curve = { version = "0.0.4", features = ["bls"] }
+hash2curve = { version = "0.0.6", features = ["bls"] }
 rayon = "1.3.0"
 sha2 = "0.8"
 serde = { version = "1.0", features = ["serde_derive"] }

--- a/libzmix/bbs/Cargo.toml
+++ b/libzmix/bbs/Cargo.toml
@@ -17,6 +17,11 @@ amcl_wrapper = { version = "0.5", default-features = false, features = ["bls381"
 arrayref = "0.3"
 failure = "0.1"
 hash2curve = { version = "0.0.6", features = ["bls"] }
+hkdf = "0.8.0"
 rayon = "1.3.0"
+rand = "0.7.3"
 sha2 = "0.8"
 serde = { version = "1.0", features = ["serde_derive"] }
+
+[dev-dependencies]
+hex = "0.4.2"

--- a/libzmix/bbs/src/keys.rs
+++ b/libzmix/bbs/src/keys.rs
@@ -1,6 +1,10 @@
 use amcl_wrapper::{
-    constants::{GROUP_G1_SIZE, GROUP_G2_SIZE}, errors::SerzDeserzError, curve_order_elem::CurveOrderElement,
-    group_elem::GroupElement, group_elem_g1::G1, group_elem_g2::G2,
+    constants::{FIELD_ORDER_ELEMENT_SIZE, GROUP_G1_SIZE, GROUP_G2_SIZE},
+    curve_order_elem::CurveOrderElement,
+    errors::SerzDeserzError,
+    group_elem::GroupElement,
+    group_elem_g1::G1,
+    group_elem_g2::G2,
 };
 use hash2curve::DomainSeparationTag;
 use hash2curve::{bls381g1::Bls12381G1Sswu, HashToCurveXmd};
@@ -159,8 +163,7 @@ impl DeterministicPublicKey {
 
     /// Convert the key to raw bytes
     pub fn to_bytes(&self) -> [u8; GROUP_G2_SIZE] {
-        let out = self.w.to_bytes();
-        *array_ref![out, 0, GROUP_G2_SIZE]
+        self.w.to_bytes()
     }
 
     /// Convert the byte slice into a public key
@@ -168,10 +171,28 @@ impl DeterministicPublicKey {
         let w = G2::from(data);
         DeterministicPublicKey { w }
     }
+
+    /// Conver the key to raw bytes in compressed form
+    pub fn to_compressed_bytes(&self) -> [u8; 2 * FIELD_ORDER_ELEMENT_SIZE] {
+        self.w.to_compressed_bytes()
+    }
 }
 
 impl From<G2> for DeterministicPublicKey {
     fn from(w: G2) -> Self {
+        DeterministicPublicKey { w }
+    }
+}
+
+impl From<[u8; 2 * FIELD_ORDER_ELEMENT_SIZE]> for DeterministicPublicKey {
+    fn from(data: [u8; 2 * FIELD_ORDER_ELEMENT_SIZE]) -> Self {
+        Self::from(&data)
+    }
+}
+
+impl From<&[u8; 2 * FIELD_ORDER_ELEMENT_SIZE]> for DeterministicPublicKey {
+    fn from(data: &[u8; 2 * FIELD_ORDER_ELEMENT_SIZE]) -> Self {
+        let w = G2::from(data);
         DeterministicPublicKey { w }
     }
 }

--- a/libzmix/bbs/src/keys.rs
+++ b/libzmix/bbs/src/keys.rs
@@ -1,11 +1,14 @@
 use amcl_wrapper::{
-    constants::{FIELD_ORDER_ELEMENT_SIZE, CURVE_ORDER_ELEMENT_SIZE, GROUP_G1_SIZE, GROUP_G2_SIZE, CURVE_ORDER},
+    constants::{
+        CURVE_ORDER, CURVE_ORDER_ELEMENT_SIZE, FIELD_ORDER_ELEMENT_SIZE, GROUP_G1_SIZE,
+        GROUP_G2_SIZE,
+    },
     curve_order_elem::CurveOrderElement,
     errors::SerzDeserzError,
     group_elem::GroupElement,
     group_elem_g1::G1,
     group_elem_g2::G2,
-    types::{DoubleBigNum, Limb}
+    types::{DoubleBigNum, Limb},
 };
 use hash2curve::DomainSeparationTag;
 use hash2curve::{bls381g1::Bls12381G1Sswu, HashToCurveXmd};
@@ -165,9 +168,7 @@ impl DeterministicPublicKey {
                 KeyGenOption::UseSeed(ref v) => generate_secret_key(Some(v)),
                 KeyGenOption::FromSecretKey(ref sk) => sk.clone(),
             },
-            None => {
-                generate_secret_key(None)
-            }
+            None => generate_secret_key(None),
         };
         let w = &G2::generator() * &secret;
         (Self { w }, secret)
@@ -282,7 +283,7 @@ pub fn generate(message_count: usize) -> Result<(PublicKey, SecretKey), BBSError
 /// we generate 64 bytes and compute mod `r`
 fn generate_secret_key(ikm: Option<&[u8]>) -> SecretKey {
     let salt = b"BBS-SIG-KEYGEN-SALT-";
-    let info = [0u8, 64u8];                 // I2OSP(L, 2)
+    let info = [0u8, 64u8]; // I2OSP(L, 2)
     let ikm = match ikm {
         Some(v) => {
             let mut t = vec![0u8; v.len() + 1];
@@ -362,13 +363,19 @@ mod tests {
         let (dpk, sk) = DeterministicPublicKey::new(Some(KeyGenOption::UseSeed(seed)));
 
         assert_eq!("0040b37f902e318f30421b6bccedd98f6e667715326b77e069a272d7adbf31584916369b53fca3118176b62d0b6d02f40cc866346280c2444388de2f1e02a9734cde9392f28484a3e5b8f04a5df011839672c4b8a189ab6b8d12ee2bd05c5f38", hex::encode(&dpk.to_compressed_bytes()[..]));
-        assert_eq!("20f7cdc7a1f940c93f721851c2babbc4de3f987dfb7ef069d30268b2d3fb0dd2", hex::encode(&sk.to_compressed_bytes()[..]));
+        assert_eq!(
+            "20f7cdc7a1f940c93f721851c2babbc4de3f987dfb7ef069d30268b2d3fb0dd2",
+            hex::encode(&sk.to_compressed_bytes()[..])
+        );
 
         let seed = vec![1u8; 24];
         let (dpk, sk) = DeterministicPublicKey::new(Some(KeyGenOption::UseSeed(seed)));
 
         assert_eq!("93e0430bfd47e54a01a2c2828432114499369f847fdcfcfa0d517448749c280350b6a960336b4fafc25e6c9119e28176075e6b98785e27f1abcde544654e6f41265bc65514290d1e4e11d5a764188d28b413b30de622c30f5247c86b5ea4d0b3", hex::encode(&dpk.to_compressed_bytes()[..]));
-        assert_eq!("22146fbf4729251777c312132cd6e2082c08b02e058d85a94b788e687de96f4e", hex::encode(&sk.to_compressed_bytes()[..]));
+        assert_eq!(
+            "22146fbf4729251777c312132cd6e2082c08b02e058d85a94b788e687de96f4e",
+            hex::encode(&sk.to_compressed_bytes()[..])
+        );
     }
 
     #[test]

--- a/libzmix/bbs/src/keys.rs
+++ b/libzmix/bbs/src/keys.rs
@@ -109,7 +109,11 @@ impl PublicKey {
             return Err(BBSErrorKind::InvalidNumberOfBytes(MIN_SIZE, data.len()).into());
         }
         let w = G2::from(array_ref![data, 0, FIELD_ORDER_ELEMENT_SIZE * 2]);
-        let h0 = G1::from(array_ref![data, FIELD_ORDER_ELEMENT_SIZE * 2, FIELD_ORDER_ELEMENT_SIZE]);
+        let h0 = G1::from(array_ref![
+            data,
+            FIELD_ORDER_ELEMENT_SIZE * 2,
+            FIELD_ORDER_ELEMENT_SIZE
+        ]);
         let h_len = u32::from_be_bytes(*array_ref![data, MIN_SIZE, 4]) as usize;
         let mut h = Vec::with_capacity(h_len);
         let mut offset = MIN_SIZE + 4;
@@ -119,9 +123,7 @@ impl PublicKey {
             offset += FIELD_ORDER_ELEMENT_SIZE;
         }
 
-        Ok(Self {
-            w, h0, h
-        })
+        Ok(Self { w, h0, h })
     }
 
     /// Make sure no generator is identity

--- a/libzmix/bbs/src/keys.rs
+++ b/libzmix/bbs/src/keys.rs
@@ -15,7 +15,7 @@ use rayon::prelude::*;
 
 /// Convenience importing module
 pub mod prelude {
-    pub use super::{generate, DeterministicPublicKey, KeyGenOption, PublicKey, SecretKey};
+    pub use super::{generate, DeterministicPublicKey, KeyGenOption, PublicKey, SecretKey, COMPRESSED_DETERMINISTIC_PUBLIC_KEY_SIZE};
     pub use hash2curve::DomainSeparationTag;
 }
 
@@ -135,6 +135,8 @@ impl PublicKey {
         }
     }
 }
+
+pub const COMPRESSED_DETERMINISTIC_PUBLIC_KEY_SIZE: usize = 2 * FIELD_ORDER_ELEMENT_SIZE;
 
 /// Used to deterministically generate all other generators given a commitment to a private key
 /// This is effectively a BLS signature public key

--- a/libzmix/bbs/src/lib.rs
+++ b/libzmix/bbs/src/lib.rs
@@ -106,6 +106,7 @@ pub mod prelude {
     pub use crate::signature::prelude::*;
     pub use crate::verifier::Verifier;
     pub use amcl_wrapper::constants::CURVE_ORDER_ELEMENT_SIZE as COMPRESSED_SECRET_KEY_SIZE;
+    pub use amcl_wrapper::constants::CURVE_ORDER_ELEMENT_SIZE as COMPRESSED_BLINDING_FACTOR_SIZE;
     pub use amcl_wrapper::constants::FIELD_ORDER_ELEMENT_SIZE as COMPRESSED_PUBLIC_KEY_SIZE;
     pub use amcl_wrapper::constants::FIELD_ORDER_ELEMENT_SIZE as SECRET_KEY_SIZE;
     pub use amcl_wrapper::constants::FIELD_ORDER_ELEMENT_SIZE as MESSAGE_SIZE;

--- a/libzmix/bbs/src/lib.rs
+++ b/libzmix/bbs/src/lib.rs
@@ -108,7 +108,6 @@ pub mod prelude {
     pub use amcl_wrapper::constants::CURVE_ORDER_ELEMENT_SIZE as COMPRESSED_SECRET_KEY_SIZE;
     pub use amcl_wrapper::constants::CURVE_ORDER_ELEMENT_SIZE as COMPRESSED_BLINDING_FACTOR_SIZE;
     pub use amcl_wrapper::constants::CURVE_ORDER_ELEMENT_SIZE as COMPRESSED_MESSAGE_SIZE;
-    pub use amcl_wrapper::constants::FIELD_ORDER_ELEMENT_SIZE as COMPRESSED_PUBLIC_KEY_SIZE;
     pub use amcl_wrapper::constants::FIELD_ORDER_ELEMENT_SIZE as SECRET_KEY_SIZE;
     pub use amcl_wrapper::constants::FIELD_ORDER_ELEMENT_SIZE as MESSAGE_SIZE;
     pub use amcl_wrapper::constants::FIELD_ORDER_ELEMENT_SIZE as NONCE_SIZE;

--- a/libzmix/bbs/src/lib.rs
+++ b/libzmix/bbs/src/lib.rs
@@ -105,6 +105,8 @@ pub mod prelude {
     pub use crate::prover::Prover;
     pub use crate::signature::prelude::*;
     pub use crate::verifier::Verifier;
+    pub use amcl_wrapper::constants::CURVE_ORDER_ELEMENT_SIZE as COMPRESSED_SECRET_KEY_SIZE;
+    pub use amcl_wrapper::constants::FIELD_ORDER_ELEMENT_SIZE as COMPRESSED_PUBLIC_KEY_SIZE;
     pub use amcl_wrapper::constants::FIELD_ORDER_ELEMENT_SIZE as SECRET_KEY_SIZE;
     pub use amcl_wrapper::constants::FIELD_ORDER_ELEMENT_SIZE as MESSAGE_SIZE;
     pub use amcl_wrapper::constants::FIELD_ORDER_ELEMENT_SIZE as NONCE_SIZE;

--- a/libzmix/bbs/src/lib.rs
+++ b/libzmix/bbs/src/lib.rs
@@ -111,6 +111,7 @@ pub mod prelude {
     pub use amcl_wrapper::constants::FIELD_ORDER_ELEMENT_SIZE as MESSAGE_SIZE;
     pub use amcl_wrapper::constants::FIELD_ORDER_ELEMENT_SIZE as NONCE_SIZE;
     pub use amcl_wrapper::constants::FIELD_ORDER_ELEMENT_SIZE as BLINDING_FACTOR_SIZE;
+    pub use amcl_wrapper::constants::FIELD_ORDER_ELEMENT_SIZE as COMPRESSED_COMMITMENT_SIZE;
     pub use amcl_wrapper::constants::GROUP_G1_SIZE as COMMITMENT_SIZE;
     pub use amcl_wrapper::group_elem::{GroupElement, GroupElementVector};
     pub use amcl_wrapper::types_g2::GROUP_G2_SIZE as PUBLIC_KEY_SIZE;

--- a/libzmix/bbs/src/lib.rs
+++ b/libzmix/bbs/src/lib.rs
@@ -107,6 +107,7 @@ pub mod prelude {
     pub use crate::verifier::Verifier;
     pub use amcl_wrapper::constants::CURVE_ORDER_ELEMENT_SIZE as COMPRESSED_SECRET_KEY_SIZE;
     pub use amcl_wrapper::constants::CURVE_ORDER_ELEMENT_SIZE as COMPRESSED_BLINDING_FACTOR_SIZE;
+    pub use amcl_wrapper::constants::CURVE_ORDER_ELEMENT_SIZE as COMPRESSED_MESSAGE_SIZE;
     pub use amcl_wrapper::constants::FIELD_ORDER_ELEMENT_SIZE as COMPRESSED_PUBLIC_KEY_SIZE;
     pub use amcl_wrapper::constants::FIELD_ORDER_ELEMENT_SIZE as SECRET_KEY_SIZE;
     pub use amcl_wrapper::constants::FIELD_ORDER_ELEMENT_SIZE as MESSAGE_SIZE;

--- a/libzmix/bbs/src/pok_sig.rs
+++ b/libzmix/bbs/src/pok_sig.rs
@@ -117,9 +117,15 @@ impl PoKOfSignature {
                 ),
             ));
         }
-        let sig_messages = messages.iter().map(|m| m.get_message()).collect::<Vec<SignatureMessage>>();
+        let sig_messages = messages
+            .iter()
+            .map(|m| m.get_message())
+            .collect::<Vec<SignatureMessage>>();
         if !signature.verify(sig_messages.as_slice(), &vk)? {
-            return Err(BBSErrorKind::PoKVCError { msg: "The messages and signature do not match.".to_string() }.into());
+            return Err(BBSErrorKind::PoKVCError {
+                msg: "The messages and signature do not match.".to_string(),
+            }
+            .into());
         }
 
         let r1 = SignatureNonce::random();

--- a/libzmix/bbs/src/pok_sig.rs
+++ b/libzmix/bbs/src/pok_sig.rs
@@ -5,7 +5,7 @@ use crate::pok_vc::prelude::*;
 use crate::signature::{compute_b_const_time, Signature};
 use crate::types::*;
 
-use amcl_wrapper::constants::{GROUP_G1_SIZE, FIELD_ORDER_ELEMENT_SIZE};
+use amcl_wrapper::constants::{FIELD_ORDER_ELEMENT_SIZE, GROUP_G1_SIZE};
 use amcl_wrapper::extension_field_gt::GT;
 use amcl_wrapper::group_elem::{GroupElement, GroupElementVector};
 use amcl_wrapper::group_elem_g1::{G1Vector, G1};
@@ -462,14 +462,9 @@ impl PoKOfSignatureProof {
             FIELD_ORDER_ELEMENT_SIZE
         ]);
         let mut offset = 2 * FIELD_ORDER_ELEMENT_SIZE;
-        let d = G1::from(array_ref![
-            data,
-            offset,
-            FIELD_ORDER_ELEMENT_SIZE
-        ]);
+        let d = G1::from(array_ref![data, offset, FIELD_ORDER_ELEMENT_SIZE]);
         offset += FIELD_ORDER_ELEMENT_SIZE;
-        let proof1_len =
-            u32::from_be_bytes(*array_ref![data, offset, 4]) as usize;
+        let proof1_len = u32::from_be_bytes(*array_ref![data, offset, 4]) as usize;
         offset += 4;
         let end = offset + proof1_len;
         let proof_vc_1 = ProofG1::from_compressed_bytes(&data[offset..end]).map_err(|e| {

--- a/libzmix/bbs/src/pok_sig.rs
+++ b/libzmix/bbs/src/pok_sig.rs
@@ -508,7 +508,8 @@ impl CompressedBytes for PoKOfSignatureProof {
     }
 
     /// Convert compressed byte slice into a proof
-    fn from_compressed_bytes(data: &[u8]) -> Result<Self, BBSError> {
+    fn from_compressed_bytes<I: AsRef<[u8]>>(data: I) -> Result<Self, BBSError> {
+        let data = data.as_ref();
         if data.len() < FIELD_ORDER_ELEMENT_SIZE * 3 {
             return Err(BBSError::from_kind(BBSErrorKind::PoKVCError {
                 msg: format!(

--- a/libzmix/bbs/src/pok_sig.rs
+++ b/libzmix/bbs/src/pok_sig.rs
@@ -488,6 +488,69 @@ impl PoKOfSignatureProof {
     }
 }
 
+impl CompressedBytes for PoKOfSignatureProof {
+    type Output = PoKOfSignatureProof;
+    type Error = BBSError;
+
+    /// Convert the proof to a compressed raw bytes form. Use when sending over the wire
+    fn to_compressed_bytes(&self) -> Vec<u8> {
+        let mut output = Vec::new();
+        output.extend_from_slice(&self.a_prime.to_compressed_bytes()[..]);
+        output.extend_from_slice(&self.a_bar.to_compressed_bytes()[..]);
+        output.extend_from_slice(&self.d.to_compressed_bytes()[..]);
+        let proof1_bytes = self.proof_vc_1.to_compressed_bytes();
+        let proof1_len = proof1_bytes.len() as u32;
+        output.extend_from_slice(&proof1_len.to_be_bytes()[..]);
+        output.extend_from_slice(proof1_bytes.as_slice());
+        output.extend_from_slice(self.proof_vc_2.to_compressed_bytes().as_slice());
+
+        output
+    }
+
+    /// Convert compressed byte slice into a proof
+    fn from_compressed_bytes(data: &[u8]) -> Result<Self, BBSError> {
+        if data.len() < FIELD_ORDER_ELEMENT_SIZE * 3 {
+            return Err(BBSError::from_kind(BBSErrorKind::PoKVCError {
+                msg: format!(
+                    "Invalid proof bytes. Expected {}",
+                    FIELD_ORDER_ELEMENT_SIZE * 3
+                ),
+            }));
+        }
+
+        let a_prime = G1::from(array_ref![data, 0, FIELD_ORDER_ELEMENT_SIZE]);
+        let a_bar = G1::from(array_ref![
+            data,
+            FIELD_ORDER_ELEMENT_SIZE,
+            FIELD_ORDER_ELEMENT_SIZE
+        ]);
+        let mut offset = 2 * FIELD_ORDER_ELEMENT_SIZE;
+        let d = G1::from(array_ref![data, offset, FIELD_ORDER_ELEMENT_SIZE]);
+        offset += FIELD_ORDER_ELEMENT_SIZE;
+        let proof1_len = u32::from_be_bytes(*array_ref![data, offset, 4]) as usize;
+        offset += 4;
+        let end = offset + proof1_len;
+        let proof_vc_1 = ProofG1::from_compressed_bytes(&data[offset..end]).map_err(|e| {
+            BBSError::from_kind(BBSErrorKind::PoKVCError {
+                msg: format!("{}", e),
+            })
+        })?;
+        let proof_vc_2 = ProofG1::from_compressed_bytes(&data[end..]).map_err(|e| {
+            BBSError::from_kind(BBSErrorKind::PoKVCError {
+                msg: format!("{}", e),
+            })
+        })?;
+
+        Ok(Self {
+            a_prime,
+            a_bar,
+            d,
+            proof_vc_1,
+            proof_vc_2,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/libzmix/bbs/src/pok_sig.rs
+++ b/libzmix/bbs/src/pok_sig.rs
@@ -341,13 +341,16 @@ impl PoKOfSignatureProof {
             .unwrap();
         match self
             .proof_vc_2
-            .verify(bases_pok_vc_2.as_slice(), &pr, challenge) {
-            Ok(b) => if b {
+            .verify(bases_pok_vc_2.as_slice(), &pr, challenge)
+        {
+            Ok(b) => {
+                if b {
                     Ok(PoKOfSignatureProofStatus::Success)
-            } else {
-                Ok(PoKOfSignatureProofStatus::BadRevealedMessage)
-            },
-            Err(_) => Ok(PoKOfSignatureProofStatus::BadRevealedMessage)
+                } else {
+                    Ok(PoKOfSignatureProofStatus::BadRevealedMessage)
+                }
+            }
+            Err(_) => Ok(PoKOfSignatureProofStatus::BadRevealedMessage),
         }
     }
 

--- a/libzmix/bbs/src/pok_sig.rs
+++ b/libzmix/bbs/src/pok_sig.rs
@@ -117,6 +117,10 @@ impl PoKOfSignature {
                 ),
             ));
         }
+        let sig_messages = messages.iter().map(|m| m.get_message()).collect::<Vec<SignatureMessage>>();
+        if !signature.verify(sig_messages.as_slice(), &vk)? {
+            return Err(BBSErrorKind::PoKVCError { msg: "The messages and signature do not match.".to_string() }.into());
+        }
 
         let r1 = SignatureNonce::random();
         let r2 = SignatureNonce::random();

--- a/libzmix/bbs/src/pok_vc.rs
+++ b/libzmix/bbs/src/pok_vc.rs
@@ -12,11 +12,11 @@
 
 use crate::prelude::*;
 
-use amcl_wrapper::field_elem::FieldElement;
+use amcl_wrapper::curve_order_elem::CurveOrderElement;
 use amcl_wrapper::group_elem::{GroupElement, GroupElementVector};
 use amcl_wrapper::group_elem_g1::{G1Vector, G1};
 use amcl_wrapper::group_elem_g2::{G2Vector, G2};
-use amcl_wrapper::{constants::GroupG1_SIZE, types_g2::GroupG2_SIZE};
+use amcl_wrapper::{constants::GROUP_G1_SIZE, types_g2::GROUP_G2_SIZE};
 use failure::{Backtrace, Context, Fail};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -147,11 +147,11 @@ macro_rules! impl_PoK_VC {
             pub fn commit(
                 &mut self,
                 gen: &$group_element,
-                blinding: Option<&FieldElement>,
+                blinding: Option<&CurveOrderElement>,
             ) -> usize {
                 let blinding = match blinding {
                     Some(b) => b.clone(),
-                    None => FieldElement::random(),
+                    None => CurveOrderElement::random(),
                 };
                 let idx = self.gens.len();
                 self.gens.push(gen.clone());
@@ -176,7 +176,7 @@ macro_rules! impl_PoK_VC {
             pub fn get_index(
                 &self,
                 idx: usize,
-            ) -> Result<(&$group_element, &FieldElement), PoKVCError> {
+            ) -> Result<(&$group_element, &CurveOrderElement), PoKVCError> {
                 if idx >= self.gens.len() {
                     return Err(PoKVCErrorKind::GeneralError {
                         msg: format!("index {} greater than size {}", idx, self.gens.len()),
@@ -198,24 +198,24 @@ macro_rules! impl_PoK_VC {
             pub fn to_bytes(&self) -> Vec<u8> {
                 let mut bytes = vec![];
                 for b in self.gens.as_slice() {
-                    bytes.append(&mut b.to_bytes());
+                    bytes.append(&mut b.to_vec());
                 }
-                bytes.append(&mut self.commitment.to_bytes());
+                bytes.append(&mut self.commitment.to_vec());
                 bytes
             }
 
             /// This step will be done by the main protocol for which this PoK is a sub-protocol
-            pub fn gen_challenge(&self, mut extra: Vec<u8>) -> FieldElement {
+            pub fn gen_challenge(&self, mut extra: Vec<u8>) -> CurveOrderElement {
                 let mut bytes = self.to_bytes();
                 bytes.append(&mut extra);
-                FieldElement::from_msg_hash(&bytes)
+                CurveOrderElement::from_msg_hash(&bytes)
             }
 
             /// For each secret, generate a response as self.blinding[i] - challenge*secrets[i].
             pub fn gen_proof(
                 self,
-                challenge: &FieldElement,
-                secrets: &[FieldElement],
+                challenge: &CurveOrderElement,
+                secrets: &[CurveOrderElement],
             ) -> Result<$Proof, PoKVCError> {
                 if secrets.len() != self.gens.len() {
                     return Err(PoKVCErrorKind::UnequalNoOfBasesExponents {
@@ -244,7 +244,7 @@ macro_rules! impl_PoK_VC {
                 &self,
                 bases: &[$group_element],
                 commitment: &$group_element,
-                challenge: &FieldElement,
+                challenge: &CurveOrderElement,
             ) -> Result<$group_element, PoKVCError> {
                 // bases[0]^responses[0] * bases[0]^responses[0] * ... bases[i]^responses[i] * commitment^challenge == random_commitment
                 // =>
@@ -271,7 +271,7 @@ macro_rules! impl_PoK_VC {
                 &self,
                 bases: &[$group_element],
                 commitment: &$group_element,
-                challenge: &FieldElement,
+                challenge: &CurveOrderElement,
             ) -> Result<bool, PoKVCError> {
                 let pr = self.get_challenge_contribution(bases, commitment, challenge)?
                     - &self.commitment;
@@ -284,7 +284,7 @@ macro_rules! impl_PoK_VC {
                 &self,
                 bases: &[$group_element],
                 commitment: &$group_element,
-                challenge: &FieldElement,
+                challenge: &CurveOrderElement,
                 nonce: &[u8],
             ) -> Result<bool, PoKVCError> {
                 if bases.len() != self.responses.len() {
@@ -303,23 +303,23 @@ macro_rules! impl_PoK_VC {
                     .unwrap();
                 let mut pr_bytes = Vec::new();
                 for b in bases.iter() {
-                    pr_bytes.append(&mut b.to_bytes())
+                    pr_bytes.append(&mut b.to_vec())
                 }
-                pr_bytes.append(&mut pr.to_bytes());
-                pr_bytes.extend_from_slice(commitment.to_bytes().as_slice());
+                pr_bytes.append(&mut pr.to_vec());
+                pr_bytes.extend_from_slice(commitment.to_vec().as_slice());
                 pr_bytes.extend_from_slice(nonce);
-                let hash = FieldElement::from_msg_hash(pr_bytes.as_slice()) - challenge;
+                let hash = CurveOrderElement::from_msg_hash(pr_bytes.as_slice()) - challenge;
                 let pr = pr - &self.commitment;
                 Ok(pr.is_identity() && hash.is_zero())
             }
 
             /// Convert to raw bytes
             pub fn to_bytes(&self) -> Vec<u8> {
-                let mut result = self.commitment.to_bytes();
+                let mut result = self.commitment.to_vec();
                 let len: u32 = self.responses.len() as u32;
                 result.extend_from_slice(&len.to_be_bytes()[..]);
                 for r in self.responses.iter() {
-                    result.extend_from_slice(r.to_bytes().as_slice());
+                    result.extend_from_slice(&r.to_bytes()[..]);
                 }
                 result
             }
@@ -333,10 +333,8 @@ macro_rules! impl_PoK_VC {
                     .into());
                 }
                 let commitment =
-                    $group_element::from_bytes(&data[..$group_element_size]).map_err(|_| {
-                        PoKVCError::from(PoKVCErrorKind::GeneralError {
-                            msg: format!("Bad data"),
-                        })
+                    $group_element::from_slice(&data[..$group_element_size]).map_err(|_| {
+                        PoKVCErrorKind::GeneralError { msg: format!("Invalid Length") }
                     })?;
 
                 let mut offset = $group_element_size;
@@ -344,7 +342,7 @@ macro_rules! impl_PoK_VC {
                 let length = u32::from_be_bytes(*array_ref![data, offset, 4]) as usize;
                 offset += 4;
 
-                if data.len() < offset + length * amcl_wrapper::constants::FieldElement_SIZE {
+                if data.len() < offset + length * amcl_wrapper::constants::FIELD_ORDER_ELEMENT_SIZE {
                     return Err(PoKVCErrorKind::GeneralError {
                         msg: format!("Invalid length"),
                     }
@@ -354,12 +352,8 @@ macro_rules! impl_PoK_VC {
                 let mut responses = SignatureMessageVector::with_capacity(length);
 
                 for _ in 0..length {
-                    let end = offset + amcl_wrapper::constants::FieldElement_SIZE;
-                    let r = FieldElement::from_bytes(&data[offset..end]).map_err(|_| {
-                        PoKVCError::from(PoKVCErrorKind::GeneralError {
-                            msg: format!("Bad data"),
-                        })
-                    })?;
+                    let end = offset + amcl_wrapper::constants::FIELD_ORDER_ELEMENT_SIZE;
+                    let r = CurveOrderElement::from(array_ref![data, offset, amcl_wrapper::constants::FIELD_ORDER_ELEMENT_SIZE]);
                     responses.push(r);
                     offset = end;
                 }
@@ -382,18 +376,18 @@ macro_rules! test_PoK_VC {
             let g = $group_element::random();
             commiting.commit(&g, None);
             gens.push(g);
-            secrets.push(FieldElement::random());
+            secrets.push(CurveOrderElement::random());
         }
 
         // Add one of the blindings externally
         let g = $group_element::random();
-        let r = FieldElement::random();
+        let r = CurveOrderElement::random();
         commiting.commit(&g, Some(&r));
         let (g_, r_) = commiting.get_index($n - 1).unwrap();
         assert_eq!(g, *g_);
         assert_eq!(r, *r_);
         gens.push(g);
-        secrets.push(FieldElement::random());
+        secrets.push(CurveOrderElement::random());
 
         // Bound check for get_index
         assert!(commiting.get_index($n).is_err());
@@ -413,9 +407,9 @@ macro_rules! test_PoK_VC {
         let proof_bytes = proof.to_bytes();
         assert_eq!(
             proof_bytes.len(),
-            $group_element::random().to_bytes().len()
+            $group_element::random().to_vec().len()
                 + 4
-                + amcl_wrapper::constants::FieldElement_SIZE * proof.responses.len()
+                + amcl_wrapper::constants::FIELD_ORDER_ELEMENT_SIZE * proof.responses.len()
         );
         let res_proof_cp = $Proof::from_bytes(&proof_bytes);
         assert!(res_proof_cp.is_ok());
@@ -442,7 +436,7 @@ macro_rules! test_PoK_VC {
             .unwrap());
         // Wrong challenge fails to verify
         assert!(!proof
-            .verify(gens.as_slice(), &commitment, &FieldElement::random())
+            .verify(gens.as_slice(), &commitment, &CurveOrderElement::random())
             .unwrap());
     };
 }
@@ -454,7 +448,7 @@ impl_PoK_VC!(
     ProofG1,
     G1,
     G1Vector,
-    GroupG1_SIZE
+    GROUP_G1_SIZE
 );
 
 // Proof of knowledge of committed values in a vector commitment. The commitment lies in group G2.
@@ -464,13 +458,13 @@ impl_PoK_VC!(
     ProofG2,
     G2,
     G2Vector,
-    GroupG2_SIZE
+    GROUP_G2_SIZE
 );
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use amcl_wrapper::field_elem::FieldElement;
+    use amcl_wrapper::curve_order_elem::CurveOrderElement;
     use amcl_wrapper::group_elem::{GroupElement, GroupElementVector};
     use amcl_wrapper::group_elem_g1::{G1Vector, G1};
     use amcl_wrapper::group_elem_g2::{G2Vector, G2};

--- a/libzmix/bbs/src/pok_vc.rs
+++ b/libzmix/bbs/src/pok_vc.rs
@@ -368,8 +368,8 @@ macro_rules! impl_PoK_VC {
                 })
             }
 
-            /// Convert to compressed raw bytes form. Use when sending over the wire
-            pub fn to_compressed_bytes(&self) -> Vec<u8> {
+            /// Convert to raw bytes using the compressed form.
+            pub fn to_bytes_compressed_form(&self) -> Vec<u8> {
                 let responses_len = self.responses.len() as u32;
                 let mut output = Vec::with_capacity(
                     $group_element_compressed_size
@@ -385,8 +385,8 @@ macro_rules! impl_PoK_VC {
                 output
             }
 
-            /// Convert from compressed bytes. Use when sending over the wire
-            pub fn from_compressed_bytes(data: &[u8]) -> Result<Self, PoKVCError> {
+            /// Convert from compressed form raw bytes.
+            pub fn from_bytes_compressed_form(data: &[u8]) -> Result<Self, PoKVCError> {
                 if data.len() < $group_element_compressed_size + 4 {
                     return Err(PoKVCErrorKind::GeneralError {
                         msg: format!("Invalid length"),
@@ -416,12 +416,12 @@ macro_rules! impl_PoK_VC {
             }
         }
 
-        impl CompressedBytes for $Proof {
+        impl CompressedForm for $Proof {
             type Output = $Proof;
             type Error = PoKVCError;
 
-            /// Convert to compressed raw bytes form. Use when sending over the wire
-            fn to_compressed_bytes(&self) -> Vec<u8> {
+            /// Convert to raw bytes using compressed form.
+            fn to_bytes_compressed_form(&self) -> Vec<u8> {
                 let responses_len = self.responses.len() as u32;
                 let mut output = Vec::with_capacity(
                     $group_element_compressed_size
@@ -437,8 +437,8 @@ macro_rules! impl_PoK_VC {
                 output
             }
 
-            /// Convert from compressed bytes. Use when sending over the wire
-            fn from_compressed_bytes<I: AsRef<[u8]>>(data: I) -> Result<Self, PoKVCError> {
+            /// Convert from compressed form raw bytes.
+            fn from_bytes_compressed_form<I: AsRef<[u8]>>(data: I) -> Result<Self, PoKVCError> {
                 let data = data.as_ref();
                 if data.len() < $group_element_compressed_size + 4 {
                     return Err(PoKVCErrorKind::GeneralError {

--- a/libzmix/bbs/src/pok_vc.rs
+++ b/libzmix/bbs/src/pok_vc.rs
@@ -12,11 +12,13 @@
 
 use crate::prelude::*;
 
+use amcl_wrapper::constants::{
+    CURVE_ORDER_ELEMENT_SIZE, FIELD_ORDER_ELEMENT_SIZE, GROUP_G1_SIZE, GROUP_G2_SIZE,
+};
 use amcl_wrapper::curve_order_elem::CurveOrderElement;
 use amcl_wrapper::group_elem::{GroupElement, GroupElementVector};
 use amcl_wrapper::group_elem_g1::{G1Vector, G1};
 use amcl_wrapper::group_elem_g2::{G2Vector, G2};
-use amcl_wrapper::constants::{GROUP_G1_SIZE, GROUP_G2_SIZE, CURVE_ORDER_ELEMENT_SIZE, FIELD_ORDER_ELEMENT_SIZE};
 use failure::{Backtrace, Context, Fail};
 use serde::{Deserialize, Serialize};
 use std::fmt;
@@ -344,8 +346,7 @@ macro_rules! impl_PoK_VC {
                 let length = u32::from_be_bytes(*array_ref![data, offset, 4]) as usize;
                 offset += 4;
 
-                if data.len() < offset + length * FIELD_ORDER_ELEMENT_SIZE
-                {
+                if data.len() < offset + length * FIELD_ORDER_ELEMENT_SIZE {
                     return Err(PoKVCErrorKind::GeneralError {
                         msg: format!("Invalid length"),
                     }
@@ -356,11 +357,8 @@ macro_rules! impl_PoK_VC {
 
                 for _ in 0..length {
                     let end = offset + FIELD_ORDER_ELEMENT_SIZE;
-                    let r = CurveOrderElement::from(array_ref![
-                        data,
-                        offset,
-                        FIELD_ORDER_ELEMENT_SIZE
-                    ]);
+                    let r =
+                        CurveOrderElement::from(array_ref![data, offset, FIELD_ORDER_ELEMENT_SIZE]);
                     responses.push(r);
                     offset = end;
                 }
@@ -374,7 +372,9 @@ macro_rules! impl_PoK_VC {
             pub fn to_compressed_bytes(&self) -> Vec<u8> {
                 let responses_len = self.responses.len() as u32;
                 let mut output = Vec::with_capacity(
-                    $group_element_compressed_size + self.responses.len() * CURVE_ORDER_ELEMENT_SIZE + 4,
+                    $group_element_compressed_size
+                        + self.responses.len() * CURVE_ORDER_ELEMENT_SIZE
+                        + 4,
                 );
 
                 output.extend_from_slice(&self.commitment.to_compressed_bytes()[..]);
@@ -397,7 +397,8 @@ macro_rules! impl_PoK_VC {
                 let commitment =
                     $group_element::from(array_ref![data, 0, $group_element_compressed_size]);
                 let responses_len =
-                    u32::from_be_bytes(*array_ref![data, $group_element_compressed_size, 4]) as usize;
+                    u32::from_be_bytes(*array_ref![data, $group_element_compressed_size, 4])
+                        as usize;
 
                 let mut offset = $group_element_compressed_size + 4;
                 let mut responses_vec = Vec::with_capacity(responses_len);

--- a/libzmix/bbs/src/pok_vc.rs
+++ b/libzmix/bbs/src/pok_vc.rs
@@ -438,7 +438,8 @@ macro_rules! impl_PoK_VC {
             }
 
             /// Convert from compressed bytes. Use when sending over the wire
-            fn from_compressed_bytes(data: &[u8]) -> Result<Self, PoKVCError> {
+            fn from_compressed_bytes<I: AsRef<[u8]>>(data: I) -> Result<Self, PoKVCError> {
+                let data = data.as_ref();
                 if data.len() < $group_element_compressed_size + 4 {
                     return Err(PoKVCErrorKind::GeneralError {
                         msg: format!("Invalid length"),

--- a/libzmix/bbs/src/prover.rs
+++ b/libzmix/bbs/src/prover.rs
@@ -60,8 +60,8 @@ impl Prover {
         let committed = committing.finish();
 
         let mut extra = Vec::new();
-        extra.extend_from_slice(commitment.to_bytes().as_slice());
-        extra.extend_from_slice(nonce.to_bytes().as_slice());
+        extra.extend_from_slice(commitment.to_vec().as_slice());
+        extra.extend_from_slice(&nonce.to_bytes()[..]);
         let challenge_hash = committed.gen_challenge(extra);
         let proof_of_hidden_messages = committed
             .gen_proof(&challenge_hash, scalars.as_slice())

--- a/libzmix/bbs/src/signature.rs
+++ b/libzmix/bbs/src/signature.rs
@@ -13,7 +13,7 @@ use std::collections::BTreeMap;
 
 /// Convenience module
 pub mod prelude {
-    pub use super::{BlindSignature, Signature, SIGNATURE_COMPRESSED_SIZE, SIGNATURE_SIZE};
+    pub use super::{BlindSignature, Signature, COMPRESSED_SIGNATURE_SIZE, SIGNATURE_SIZE};
 }
 
 macro_rules! check_verkey_message {
@@ -29,7 +29,7 @@ macro_rules! check_verkey_message {
 /// The number of bytes in a signature
 pub const SIGNATURE_SIZE: usize = GROUP_G1_SIZE + FIELD_ORDER_ELEMENT_SIZE * 2;
 /// The number of bytes in a compressed signature
-pub const SIGNATURE_COMPRESSED_SIZE: usize =
+pub const COMPRESSED_SIGNATURE_SIZE: usize =
     FIELD_ORDER_ELEMENT_SIZE + CURVE_ORDER_ELEMENT_SIZE * 2;
 
 macro_rules! sig_byte_impl {
@@ -44,8 +44,8 @@ macro_rules! sig_byte_impl {
         }
 
         /// Conver the signature to a compressed form of raw bytes. Use when sending over the wire.
-        pub fn to_compressed_bytes(&self) -> [u8; SIGNATURE_COMPRESSED_SIZE] {
-            let mut out = [0u8; SIGNATURE_COMPRESSED_SIZE];
+        pub fn to_compressed_bytes(&self) -> [u8; COMPRESSED_SIGNATURE_SIZE] {
+            let mut out = [0u8; COMPRESSED_SIGNATURE_SIZE];
             out[..FIELD_ORDER_ELEMENT_SIZE].copy_from_slice(&self.a.to_compressed_bytes()[..]);
             let end = FIELD_ORDER_ELEMENT_SIZE + CURVE_ORDER_ELEMENT_SIZE;
             out[FIELD_ORDER_ELEMENT_SIZE..end].copy_from_slice(&self.e.to_compressed_bytes()[..]);
@@ -68,14 +68,14 @@ macro_rules! sig_byte_impl {
 
 macro_rules! from_rules {
     ($type:ident) => {
-        impl From<[u8; SIGNATURE_COMPRESSED_SIZE]> for $type {
-            fn from(data: [u8; SIGNATURE_COMPRESSED_SIZE]) -> Self {
+        impl From<[u8; COMPRESSED_SIGNATURE_SIZE]> for $type {
+            fn from(data: [u8; COMPRESSED_SIGNATURE_SIZE]) -> Self {
                 Self::from(&data)
             }
         }
 
-        impl From<&[u8; SIGNATURE_COMPRESSED_SIZE]> for $type {
-            fn from(data: &[u8; SIGNATURE_COMPRESSED_SIZE]) -> Self {
+        impl From<&[u8; COMPRESSED_SIGNATURE_SIZE]> for $type {
+            fn from(data: &[u8; COMPRESSED_SIGNATURE_SIZE]) -> Self {
                 let a = G1::from(*array_ref![data, 0, FIELD_ORDER_ELEMENT_SIZE]);
                 let e = SignatureMessage::from(array_ref![
                     data,
@@ -304,7 +304,7 @@ mod tests {
         assert_eq!(sig, sig_2);
 
         let bytes = sig.to_compressed_bytes();
-        assert_eq!(bytes.len(), SIGNATURE_COMPRESSED_SIZE);
+        assert_eq!(bytes.len(), COMPRESSED_SIGNATURE_SIZE);
         let sig_2 = Signature::from(bytes);
         assert_eq!(sig, sig_2);
     }

--- a/libzmix/bbs/src/signature.rs
+++ b/libzmix/bbs/src/signature.rs
@@ -43,8 +43,8 @@ macro_rules! sig_byte_impl {
             *array_ref![out, 0, SIGNATURE_SIZE]
         }
 
-        /// Conver the signature to a compressed form of raw bytes. Use when sending over the wire.
-        pub fn to_compressed_bytes(&self) -> [u8; COMPRESSED_SIGNATURE_SIZE] {
+        /// Convert the signature to bytes using compressed form.
+        pub fn to_bytes_compressed_form(&self) -> [u8; COMPRESSED_SIGNATURE_SIZE] {
             let mut out = [0u8; COMPRESSED_SIGNATURE_SIZE];
             out[..FIELD_ORDER_ELEMENT_SIZE].copy_from_slice(&self.a.to_compressed_bytes()[..]);
             let end = FIELD_ORDER_ELEMENT_SIZE + CURVE_ORDER_ELEMENT_SIZE;
@@ -303,7 +303,7 @@ mod tests {
         let sig_2 = Signature::from_bytes(bytes);
         assert_eq!(sig, sig_2);
 
-        let bytes = sig.to_compressed_bytes();
+        let bytes = sig.to_bytes_compressed_form();
         assert_eq!(bytes.len(), COMPRESSED_SIGNATURE_SIZE);
         let sig_2 = Signature::from(bytes);
         assert_eq!(sig, sig_2);

--- a/libzmix/bbs/src/signature.rs
+++ b/libzmix/bbs/src/signature.rs
@@ -13,7 +13,7 @@ use std::collections::BTreeMap;
 
 /// Convenience module
 pub mod prelude {
-    pub use super::{BlindSignature, Signature, SIGNATURE_SIZE};
+    pub use super::{BlindSignature, Signature, SIGNATURE_COMPRESSED_SIZE, SIGNATURE_SIZE};
 }
 
 macro_rules! check_verkey_message {
@@ -77,12 +77,12 @@ macro_rules! from_rules {
         impl From<&[u8; SIGNATURE_COMPRESSED_SIZE]> for $type {
             fn from(data: &[u8; SIGNATURE_COMPRESSED_SIZE]) -> Self {
                 let a = G1::from(*array_ref![data, 0, FIELD_ORDER_ELEMENT_SIZE]);
-                let e = SignatureMessage::from(*array_ref![
+                let e = SignatureMessage::from(array_ref![
                     data,
                     FIELD_ORDER_ELEMENT_SIZE,
                     CURVE_ORDER_ELEMENT_SIZE
                 ]);
-                let s = SignatureMessage::from(*array_ref![
+                let s = SignatureMessage::from(array_ref![
                     data,
                     FIELD_ORDER_ELEMENT_SIZE + CURVE_ORDER_ELEMENT_SIZE,
                     CURVE_ORDER_ELEMENT_SIZE

--- a/libzmix/bbs/src/verifier.rs
+++ b/libzmix/bbs/src/verifier.rs
@@ -44,7 +44,7 @@ impl Verifier {
             proof_request.revealed_messages.clone(),
             &proof_request.verification_key,
         );
-        challenge_bytes.extend_from_slice(nonce.to_bytes().as_slice());
+        challenge_bytes.extend_from_slice(&nonce.to_bytes()[..]);
 
         let challenge_verifier = SignatureNonce::from_msg_hash(&challenge_bytes);
         match signature_proof.proof.verify(

--- a/libzmix/bbs/tests/bbs.rs
+++ b/libzmix/bbs/tests/bbs.rs
@@ -236,10 +236,10 @@ fn pok_sig_bad_message() {
     let signature = Signature::new(messages.as_slice(), &sk, &pk).unwrap();
 
     let nonce = Verifier::generate_proof_nonce();
-    let proof_request = Verifier::new_proof_request(&[1, 3], &pk).unwrap();
+    let mut proof_request = Verifier::new_proof_request(&[1, 3], &pk).unwrap();
 
     // Sends `proof_request` and `nonce` to the prover
-    let proof_messages = vec![
+    let mut proof_messages = vec![
         pm_hidden!(b"message_0"), //message that wasn't signed
         pm_revealed!(b"message_2"),
         pm_hidden!(b"message_3"),
@@ -247,8 +247,11 @@ fn pok_sig_bad_message() {
         pm_hidden!(b"message_5"),
     ];
 
-    let pok = Prover::commit_signature_pok(&proof_request, proof_messages.as_slice(), &signature)
-        .unwrap();
+    let res = Prover::commit_signature_pok(&proof_request, proof_messages.as_slice(), &signature);
+    assert!(res.is_err());
+    proof_messages[0] = pm_hidden!(b"message_1");
+    let pok = Prover::commit_signature_pok(&proof_request, proof_messages.as_slice(), &signature).unwrap();
+
     let mut challenge_bytes = Vec::new();
     challenge_bytes.extend_from_slice(pok.to_bytes().as_slice());
     challenge_bytes.extend_from_slice(&nonce.to_bytes()[..]);
@@ -256,30 +259,7 @@ fn pok_sig_bad_message() {
     let challenge = SignatureNonce::from_msg_hash(&challenge_bytes);
 
     let proof = Prover::generate_signature_pok(pok, &challenge).unwrap();
-
-    match Verifier::verify_signature_pok(&proof_request, &proof, &nonce) {
-        Ok(_) => assert!(false),
-        Err(_) => assert!(true),
-    };
-
-    // Sends `proof_request` and `nonce` to the prover
-    let proof_messages = vec![
-        pm_revealed!(b"message_0"), //message that wasn't signed
-        pm_revealed!(b"message_2"),
-        pm_hidden!(b"message_3"),
-        pm_revealed!(b"message_4"),
-        pm_hidden!(b"message_5"),
-    ];
-
-    let pok = Prover::commit_signature_pok(&proof_request, proof_messages.as_slice(), &signature)
-        .unwrap();
-    let mut challenge_bytes = Vec::new();
-    challenge_bytes.extend_from_slice(pok.to_bytes().as_slice());
-    challenge_bytes.extend_from_slice(&nonce.to_bytes()[..]);
-
-    let challenge = SignatureNonce::from_msg_hash(&challenge_bytes);
-
-    let proof = Prover::generate_signature_pok(pok, &challenge).unwrap();
+    proof_request.revealed_messages.insert(0);
 
     match Verifier::verify_signature_pok(&proof_request, &proof, &nonce) {
         Ok(_) => assert!(false),
@@ -287,25 +267,15 @@ fn pok_sig_bad_message() {
     };
 
     let proof_request = Verifier::new_proof_request(&[0, 1, 2, 3], &pk).unwrap();
-
-    // Sends `proof_request` and `nonce` to the prover
-    let proof_messages = vec![
-        pm_revealed!(b"message_1"), //message that wasn't signed
-        pm_revealed!(b"message_2"),
-        pm_hidden!(b"message_3"),
-        pm_revealed!(b"message_4"),
-        pm_hidden!(b"message_5"),
-    ];
-
-    let pok = Prover::commit_signature_pok(&proof_request, proof_messages.as_slice(), &signature)
-        .unwrap();
+    let pok = Prover::commit_signature_pok(&proof_request, proof_messages.as_slice(), &signature).unwrap();
     let mut challenge_bytes = Vec::new();
     challenge_bytes.extend_from_slice(pok.to_bytes().as_slice());
     challenge_bytes.extend_from_slice(&nonce.to_bytes()[..]);
 
     let challenge = SignatureNonce::from_msg_hash(&challenge_bytes);
 
-    let proof = Prover::generate_signature_pok(pok, &challenge).unwrap();
+    let mut proof = Prover::generate_signature_pok(pok, &challenge).unwrap();
+    proof.revealed_messages.insert(0, SignatureMessage::from_msg_hash(b"message_1"));
 
     //The proof is not what the verifier asked for
     match Verifier::verify_signature_pok(&proof_request, &proof, &nonce) {
@@ -313,3 +283,4 @@ fn pok_sig_bad_message() {
         Err(_) => assert!(true),
     };
 }
+

--- a/libzmix/bbs/tests/bbs.rs
+++ b/libzmix/bbs/tests/bbs.rs
@@ -141,7 +141,7 @@ fn pok_sig() {
 
     let mut challenge_bytes = Vec::new();
     challenge_bytes.extend_from_slice(pok.to_bytes().as_slice());
-    challenge_bytes.extend_from_slice(nonce.to_bytes().as_slice());
+    challenge_bytes.extend_from_slice(&nonce.to_bytes()[..]);
 
     let challenge = SignatureNonce::from_msg_hash(&challenge_bytes);
 

--- a/libzmix/bbs/tests/bbs.rs
+++ b/libzmix/bbs/tests/bbs.rs
@@ -154,3 +154,68 @@ fn pok_sig() {
         Err(_) => assert!(false), // Why did the proof failed
     };
 }
+
+#[test]
+fn pok_sig_extra_message() {
+
+    let (pk, sk) = Issuer::new_keys(5).unwrap();
+    let messages = vec![
+        SignatureMessage::from_msg_hash(b"message_1"),
+        SignatureMessage::from_msg_hash(b"message_2"),
+        SignatureMessage::from_msg_hash(b"message_3"),
+        SignatureMessage::from_msg_hash(b"message_4"),
+        SignatureMessage::from_msg_hash(b"message_5"),
+    ];
+
+    let signature = Signature::new(messages.as_slice(), &sk, &pk).unwrap();
+
+    let nonce = Verifier::generate_proof_nonce();
+    let mut proof_request = Verifier::new_proof_request(&[1, 3], &pk).unwrap();
+
+    // Sends `proof_request` and `nonce` to the prover
+    let proof_messages = vec![
+        pm_hidden!(b"message_1"),
+        pm_revealed!(b"message_2"),
+        pm_hidden!(b"message_3"),
+        pm_revealed!(b"message_4"),
+        pm_hidden!(b"message_5"),
+    ];
+
+    let pok = Prover::commit_signature_pok(&proof_request, proof_messages.as_slice(), &signature).unwrap();
+
+    // complete other zkps as desired and compute `challenge_hash`
+    // add bytes from other proofs
+
+    let mut challenge_bytes = Vec::new();
+    challenge_bytes.extend_from_slice(pok.to_bytes().as_slice());
+    challenge_bytes.extend_from_slice(&nonce.to_bytes()[..]);
+
+    let challenge = SignatureNonce::from_msg_hash(&challenge_bytes);
+
+    let mut proof = Prover::generate_signature_pok(pok, &challenge).unwrap();
+
+    // Reveal a message that was hidden, should fail
+    proof_request.revealed_messages.insert(4);
+
+    // Send `proof` and `challenge` to Verifier
+
+    match Verifier::verify_signature_pok(&proof_request, &proof, &nonce) {
+        Ok(_) => assert!(false),
+        Err(_) => assert!(true),
+    };
+
+    proof_request.revealed_messages.remove(&4);
+    proof.revealed_messages.insert(4, SignatureMessage::from_msg_hash(b"message_4"));
+
+    match Verifier::verify_signature_pok(&proof_request, &proof, &nonce) {
+        Ok(_) => assert!(false),
+        Err(_) => assert!(true),
+    };
+
+    proof.revealed_messages.remove(&4);
+    proof.revealed_messages.insert(3, SignatureMessage::new());
+    match Verifier::verify_signature_pok(&proof_request, &proof, &nonce) {
+        Ok(_) => assert!(false),
+        Err(_) => assert!(true),
+    };
+}

--- a/libzmix/bbs/tests/bbs.rs
+++ b/libzmix/bbs/tests/bbs.rs
@@ -250,7 +250,8 @@ fn pok_sig_bad_message() {
     let res = Prover::commit_signature_pok(&proof_request, proof_messages.as_slice(), &signature);
     assert!(res.is_err());
     proof_messages[0] = pm_hidden!(b"message_1");
-    let pok = Prover::commit_signature_pok(&proof_request, proof_messages.as_slice(), &signature).unwrap();
+    let pok = Prover::commit_signature_pok(&proof_request, proof_messages.as_slice(), &signature)
+        .unwrap();
 
     let mut challenge_bytes = Vec::new();
     challenge_bytes.extend_from_slice(pok.to_bytes().as_slice());
@@ -267,7 +268,8 @@ fn pok_sig_bad_message() {
     };
 
     let proof_request = Verifier::new_proof_request(&[0, 1, 2, 3], &pk).unwrap();
-    let pok = Prover::commit_signature_pok(&proof_request, proof_messages.as_slice(), &signature).unwrap();
+    let pok = Prover::commit_signature_pok(&proof_request, proof_messages.as_slice(), &signature)
+        .unwrap();
     let mut challenge_bytes = Vec::new();
     challenge_bytes.extend_from_slice(pok.to_bytes().as_slice());
     challenge_bytes.extend_from_slice(&nonce.to_bytes()[..]);
@@ -275,7 +277,9 @@ fn pok_sig_bad_message() {
     let challenge = SignatureNonce::from_msg_hash(&challenge_bytes);
 
     let mut proof = Prover::generate_signature_pok(pok, &challenge).unwrap();
-    proof.revealed_messages.insert(0, SignatureMessage::from_msg_hash(b"message_1"));
+    proof
+        .revealed_messages
+        .insert(0, SignatureMessage::from_msg_hash(b"message_1"));
 
     //The proof is not what the verifier asked for
     match Verifier::verify_signature_pok(&proof_request, &proof, &nonce) {
@@ -283,4 +287,3 @@ fn pok_sig_bad_message() {
         Err(_) => assert!(true),
     };
 }
-

--- a/libzmix/bbs/tests/bbs.rs
+++ b/libzmix/bbs/tests/bbs.rs
@@ -221,3 +221,68 @@ fn pok_sig_extra_message() {
         Err(_) => assert!(true),
     };
 }
+
+#[test]
+fn pok_sig_bad_message() {
+    let (pk, sk) = Issuer::new_keys(5).unwrap();
+    let messages = vec![
+        SignatureMessage::from_msg_hash(b"message_1"),
+        SignatureMessage::from_msg_hash(b"message_2"),
+        SignatureMessage::from_msg_hash(b"message_3"),
+        SignatureMessage::from_msg_hash(b"message_4"),
+        SignatureMessage::from_msg_hash(b"message_5"),
+    ];
+
+    let signature = Signature::new(messages.as_slice(), &sk, &pk).unwrap();
+
+    let nonce = Verifier::generate_proof_nonce();
+    let proof_request = Verifier::new_proof_request(&[1, 3], &pk).unwrap();
+
+    // Sends `proof_request` and `nonce` to the prover
+    let proof_messages = vec![
+        pm_hidden!(b"message_0"), //message that wasn't signed
+        pm_revealed!(b"message_2"),
+        pm_hidden!(b"message_3"),
+        pm_revealed!(b"message_4"),
+        pm_hidden!(b"message_5"),
+    ];
+
+    let pok = Prover::commit_signature_pok(&proof_request, proof_messages.as_slice(), &signature)
+        .unwrap();
+    let mut challenge_bytes = Vec::new();
+    challenge_bytes.extend_from_slice(pok.to_bytes().as_slice());
+    challenge_bytes.extend_from_slice(&nonce.to_bytes()[..]);
+
+    let challenge = SignatureNonce::from_msg_hash(&challenge_bytes);
+
+    let proof = Prover::generate_signature_pok(pok, &challenge).unwrap();
+
+    match Verifier::verify_signature_pok(&proof_request, &proof, &nonce) {
+        Ok(_) => assert!(false),
+        Err(_) => assert!(true),
+    };
+
+    // Sends `proof_request` and `nonce` to the prover
+    let proof_messages = vec![
+        pm_revealed!(b"message_0"), //message that wasn't signed
+        pm_revealed!(b"message_2"),
+        pm_hidden!(b"message_3"),
+        pm_revealed!(b"message_4"),
+        pm_hidden!(b"message_5"),
+    ];
+
+    let pok = Prover::commit_signature_pok(&proof_request, proof_messages.as_slice(), &signature)
+        .unwrap();
+    let mut challenge_bytes = Vec::new();
+    challenge_bytes.extend_from_slice(pok.to_bytes().as_slice());
+    challenge_bytes.extend_from_slice(&nonce.to_bytes()[..]);
+
+    let challenge = SignatureNonce::from_msg_hash(&challenge_bytes);
+
+    let proof = Prover::generate_signature_pok(pok, &challenge).unwrap();
+
+    match Verifier::verify_signature_pok(&proof_request, &proof, &nonce) {
+        Ok(_) => assert!(false),
+        Err(_) => assert!(true),
+    };
+}

--- a/libzmix/bbs/tests/bbs.rs
+++ b/libzmix/bbs/tests/bbs.rs
@@ -157,7 +157,6 @@ fn pok_sig() {
 
 #[test]
 fn pok_sig_extra_message() {
-
     let (pk, sk) = Issuer::new_keys(5).unwrap();
     let messages = vec![
         SignatureMessage::from_msg_hash(b"message_1"),
@@ -181,7 +180,8 @@ fn pok_sig_extra_message() {
         pm_hidden!(b"message_5"),
     ];
 
-    let pok = Prover::commit_signature_pok(&proof_request, proof_messages.as_slice(), &signature).unwrap();
+    let pok = Prover::commit_signature_pok(&proof_request, proof_messages.as_slice(), &signature)
+        .unwrap();
 
     // complete other zkps as desired and compute `challenge_hash`
     // add bytes from other proofs
@@ -205,7 +205,9 @@ fn pok_sig_extra_message() {
     };
 
     proof_request.revealed_messages.remove(&4);
-    proof.revealed_messages.insert(4, SignatureMessage::from_msg_hash(b"message_4"));
+    proof
+        .revealed_messages
+        .insert(4, SignatureMessage::from_msg_hash(b"message_4"));
 
     match Verifier::verify_signature_pok(&proof_request, &proof, &nonce) {
         Ok(_) => assert!(false),


### PR DESCRIPTION
This PR updates to a newer version of amcl_wrapper as well as implements a compressed form for keys and proofs. 

For example, points can be stored as just the x-coordinates. Curve order elements can remove leading zero bytes.

The result is that points in G1 drop to 48 bytes, G2 drop to 96 bytes, and elements in Zq drop to 32 bytes.

The major gains come from proof sizes. A proof with 5 hidden messages is 933 bytes in uncompressed form and 530 in compressed form.

Public Key sizes go down to 1/2.

Signatures go from 193 bytes to 112 bytes.