### PR TITLE
BBS+ demo

### DIFF
--- a/libzmix/bbs/tests/bbs.rs
+++ b/libzmix/bbs/tests/bbs.rs
@@ -270,6 +270,74 @@ fn pok_sig_bad_message() {
 }
 
 #[test]
+fn test_challenge_hash_with_prover_claims() {
+    //issue credential
+    let (pk, sk) = Issuer::new_keys(5).unwrap();
+    let messages = vec![
+        SignatureMessage::from_msg_hash(b"message_1"),
+        SignatureMessage::from_msg_hash(b"message_2"),
+        SignatureMessage::from_msg_hash(b"message_3"),
+        SignatureMessage::from_msg_hash(b"message_4"),
+        SignatureMessage::from_msg_hash(b"message_5"),
+    ];
+
+    let signature = Signature::new(messages.as_slice(), &sk, &pk).unwrap();
+
+    //verifier requests credential
+    let nonce = Verifier::generate_proof_nonce();
+    let proof_request = Verifier::new_proof_request(&[1, 3], &pk).unwrap();
+
+    // Sends `proof_request` and `nonce` to the prover
+    let proof_messages = vec![
+        pm_hidden!(b"message_1"),
+        pm_revealed!(b"message_2"),
+        pm_hidden!(b"message_3"),
+        pm_revealed!(b"message_4"),
+        pm_hidden!(b"message_5"),
+    ];
+
+    // prover creates pok for proof request
+    let pok = Prover::commit_signature_pok(&proof_request, proof_messages.as_slice(), &signature)
+        .unwrap();
+
+    let claims = vec!["self-attested claim1", "self-attested claim2"];
+
+    // complete other zkps as desired and compute `challenge_hash`
+    let challenge =
+        Prover::create_challenge_hash(vec![pok.clone()], claims.clone(), &nonce).unwrap();
+
+    let proof = Prover::generate_signature_pok(pok, &challenge).unwrap();
+
+    // Send `proof`, `claims`, and `challenge` to Verifier
+
+    // Verifier creates their own challenge bytes
+    // and adds proof and claims to it
+    let mut ver_chal_bytes = proof.proof.get_bytes_for_challenge(
+        proof_request.revealed_messages.clone(),
+        &proof_request.verification_key,
+    );
+    for c in claims {
+        ver_chal_bytes.extend_from_slice(c.as_bytes());
+    }
+
+    // Verifier completes ver_challenge_bytes by adding verifier_nonce,
+    // then constructs the challenge
+    ver_chal_bytes.extend_from_slice(&nonce.to_bytes()[..]);
+    let ver_challenge = SignatureNonce::from_msg_hash(&ver_chal_bytes);
+
+    // Verifier checks proof1
+    let res = proof.proof.verify(
+        &proof_request.verification_key,
+        &proof.revealed_messages,
+        &ver_challenge,
+    );
+    match res {
+        Ok(_) => assert!(true),   // check revealed messages
+        Err(_) => assert!(false), // Why did the proof fail?
+    };
+}
+
+#[test]
 fn bbs_demo() {
     // Prover generates link secret
     let link_secret = Prover::new_link_secret();

--- a/libzmix/bbs/tests/bbs.rs
+++ b/libzmix/bbs/tests/bbs.rs
@@ -477,28 +477,22 @@ fn bbs_demo() {
     let ver_challenge = SignatureNonce::from_msg_hash(&ver_chal_bytes);
 
     // Verifier checks proof1
-    let res1 =
-        proof1
-            .proof
-            .verify(
-                &proof_request1.verification_key,
-                &proof1.revealed_messages,
-                &ver_challenge,
-            );
+    let res1 = proof1.proof.verify(
+        &proof_request1.verification_key,
+        &proof1.revealed_messages,
+        &ver_challenge,
+    );
     match res1 {
         Ok(_) => assert!(true),   // check revealed messages
         Err(_) => assert!(false), // Why did the proof fail?
     };
 
     // Verifier checks proof1
-    let res2 =
-        proof2
-            .proof
-            .verify(
-                &proof_request2.verification_key,
-                &proof2.revealed_messages,
-                &ver_challenge,
-            );
+    let res2 = proof2.proof.verify(
+        &proof_request2.verification_key,
+        &proof2.revealed_messages,
+        &ver_challenge,
+    );
     match res2 {
         Ok(_) => assert!(true),   // check revealed messages
         Err(_) => assert!(false), // Why did the proof fail?

--- a/libzmix/bbs/tests/bbs.rs
+++ b/libzmix/bbs/tests/bbs.rs
@@ -512,6 +512,7 @@ fn bbs_demo() {
     // Verifier checks proof1
         &ver_challenge,
     );
+    match res1 {
         Ok(_) => assert!(true),   // check revealed messages
         Err(_) => assert!(false), // Why did the proof fail?
     };
@@ -522,7 +523,7 @@ fn bbs_demo() {
         &proof2.revealed_messages,
         &ver_challenge,
     );
-    match res2{
+    match res2 {
         Ok(_) => assert!(true),   // check revealed messages
         Err(_) => assert!(false), // Why did the proof fail?
     };

--- a/libzmix/bbs/tests/bbs.rs
+++ b/libzmix/bbs/tests/bbs.rs
@@ -299,20 +299,11 @@ fn bbs_demo() {
     // Prover generates blind signature context and sends it to Issuer1
     // Prover stores signature blinding
     let (ctx1, signature_blinding1) =
-        Prover::new_blind_signature_context(
-            &pk1,
-            &blind_claims1,
-            &signing_nonce1
-        ).unwrap();
+        Prover::new_blind_signature_context(&pk1, &blind_claims1, &signing_nonce1).unwrap();
 
     // Issuer1 signs the credential and sends it to the Prover
-    let blind_signature1 = Issuer::blind_sign(
-        &ctx1,
-        &credential1,
-        &sk1,
-        &pk1,
-        &signing_nonce1
-    ).unwrap();
+    let blind_signature1 =
+        Issuer::blind_sign(&ctx1, &credential1, &sk1, &pk1, &signing_nonce1).unwrap();
 
     // Prover adds link secret to the credential from Issuer1
     let mut full_credential1 = credential1
@@ -322,22 +313,19 @@ fn bbs_demo() {
     full_credential1.insert(0, link_secret.clone());
 
     // Prover completes the signature from Issuer1
-    let complete_signature1 =
-        Prover::complete_signature(
-            &pk1,
-            full_credential1.as_slice(),
-            &blind_signature1,
-            &signature_blinding1);
+    let complete_signature1 = Prover::complete_signature(
+        &pk1,
+        full_credential1.as_slice(),
+        &blind_signature1,
+        &signature_blinding1,
+    );
 
     // Prover verifies the signature from Issuer1
     assert!(complete_signature1.is_ok());
     let complete_sig1 = complete_signature1.unwrap();
     assert!(complete_sig1
-        .verify(
-            full_credential1.as_slice(),
-            &pk1
-        ).unwrap()
-    );
+        .verify(full_credential1.as_slice(), &pk1)
+        .unwrap());
 
     // Issuer2 creates keys to sign a credential with 4 claims
     // (one of which is the blinded link secret)
@@ -363,20 +351,11 @@ fn bbs_demo() {
     // Prover generates blind signature context and sends it to Issuer2
     // Prover stores signature blinding
     let (ctx2, signature_blinding2) =
-        Prover::new_blind_signature_context(
-            &pk2,
-            &blind_claims2,
-            &signing_nonce2
-        ).unwrap();
+        Prover::new_blind_signature_context(&pk2, &blind_claims2, &signing_nonce2).unwrap();
 
     // Issuer2 signs the credential and sends it to the Prover
-    let blind_signature2 = Issuer::blind_sign(
-        &ctx2,
-        &credential2,
-        &sk2,
-        &pk2,
-        &signing_nonce2
-    ).unwrap();
+    let blind_signature2 =
+        Issuer::blind_sign(&ctx2, &credential2, &sk2, &pk2, &signing_nonce2).unwrap();
 
     // Prover adds link secret to the credential from Issuer2
     let mut full_credential2 = credential2
@@ -389,22 +368,19 @@ fn bbs_demo() {
     assert_eq!(full_credential1[2], full_credential2[3]);
 
     // Prover completes the signature from Issuer2
-    let complete_signature2 =
-        Prover::complete_signature(
-            &pk2,
-            full_credential2.as_slice(),
-            &blind_signature2,
-            &signature_blinding2);
+    let complete_signature2 = Prover::complete_signature(
+        &pk2,
+        full_credential2.as_slice(),
+        &blind_signature2,
+        &signature_blinding2,
+    );
 
     // Prover verifies the signature from Issuer1
     assert!(complete_signature2.is_ok());
     let complete_sig2 = complete_signature2.unwrap();
     assert!(complete_sig2
-        .verify(
-            full_credential2.as_slice(),
-            &pk2
-        ).unwrap()
-    );
+        .verify(full_credential2.as_slice(), &pk2)
+        .unwrap());
 
     // Verifier wants the Prover to reveal claim1 from Issuer1,
     // plus a proof that claim2 from Issuer1 and claim3 from Issuer2 are identical
@@ -412,18 +388,10 @@ fn bbs_demo() {
     let verifier_nonce = Verifier::generate_proof_nonce();
 
     // Verifier creates proof request for the reveal of claim1 from credential1 from Issuer1
-    let proof_request1 =
-        Verifier::new_proof_request(
-            &[1],
-            &pk1
-        ).unwrap();
+    let proof_request1 = Verifier::new_proof_request(&[1], &pk1).unwrap();
 
     // Verifier creates proof request for credential2 from Issuer2
-    let proof_request2 =
-        Verifier::new_proof_request(
-            &[],
-            &pk2
-        ).unwrap();
+    let proof_request2 = Verifier::new_proof_request(&[], &pk2).unwrap();
 
     // Verifier sends verifier_nonce, proof_request1, and proof_request2 to Prover
     // and additionally communicates the request for a ZK equality proof of
@@ -443,16 +411,13 @@ fn bbs_demo() {
         pm_revealed!(b"claim1_first_name"),
         pm_hidden_raw!(same_claim.clone(), same_blinding.clone()),
         pm_hidden!(b"claim3_email"),
-        pm_hidden!(b"claim4_address")
+        pm_hidden!(b"claim4_address"),
     ];
 
     // Prover constructs signature proof of knowledge for credential1
     let pok1 =
-        Prover::commit_signature_pok(
-            &proof_request1,
-            proof_messages1.as_slice(),
-            &complete_sig1
-        ).unwrap();
+        Prover::commit_signature_pok(&proof_request1, proof_messages1.as_slice(), &complete_sig1)
+            .unwrap();
 
     // Prover constructs proof messages from credential2
     // for ZK equality proof of claim3
@@ -460,16 +425,13 @@ fn bbs_demo() {
         pm_hidden_raw!(link_secret.clone(), link_secret_blinding.clone()),
         pm_hidden!(b"claim1_loyalty_program_id"),
         pm_hidden!(b"claim2_customer_id"),
-        pm_hidden_raw!(same_claim.clone(), same_blinding.clone())
+        pm_hidden_raw!(same_claim.clone(), same_blinding.clone()),
     ];
 
     // Prover constructs signature proof of knowledge for credential2
     let pok2 =
-        Prover::commit_signature_pok(
-            &proof_request2,
-            proof_messages2.as_slice(),
-            &complete_sig2
-        ).unwrap();
+        Prover::commit_signature_pok(&proof_request2, proof_messages2.as_slice(), &complete_sig2)
+            .unwrap();
 
 
     // Prover creates challenge_bytes and adds pok1 and pok2 to it.
@@ -483,14 +445,8 @@ fn bbs_demo() {
     let challenge = SignatureNonce::from_msg_hash(&chal_bytes);
 
     // Prover constructs the proofs and sends them to the Verifier
-    let proof1 = Prover::generate_signature_pok(
-        pok1,
-        &challenge
-    ).unwrap();
-    let proof2 = Prover::generate_signature_pok(
-        pok2,
-        &challenge
-    ).unwrap();
+    let proof1 = Prover::generate_signature_pok(pok1, &challenge).unwrap();
+    let proof2 = Prover::generate_signature_pok(pok2, &challenge).unwrap();
 
     // Verifier creates their own challenge bytes
     // and adds proof1 and proof2 to it
@@ -499,10 +455,13 @@ fn bbs_demo() {
         &proof_request1.verification_key,
     );
     ver_chal_bytes.extend_from_slice(
-        proof2.proof.get_bytes_for_challenge(
-            proof_request2.revealed_messages.clone(),
-            &proof_request2.verification_key,
-        ).as_slice()
+        proof2
+            .proof
+            .get_bytes_for_challenge(
+                proof_request2.revealed_messages.clone(),
+                &proof_request2.verification_key,
+            )
+            .as_slice(),
     );
 
     // Verifier completes ver_challenge_bytes by adding verifier_nonce,
@@ -510,19 +469,28 @@ fn bbs_demo() {
     let ver_challenge = SignatureNonce::from_msg_hash(&ver_chal_bytes);
 
     // Verifier checks proof1
-        &ver_challenge,
-    );
+    let res1 =
+        proof1
+            .proof
+            .verify(
+                &proof_request1.verification_key,
+                &proof1.revealed_messages,
+                &ver_challenge,
+            );
     match res1 {
         Ok(_) => assert!(true),   // check revealed messages
         Err(_) => assert!(false), // Why did the proof fail?
     };
 
     // Verifier checks proof1
-    let res2 = proof2.proof.verify(
-        &proof_request2.verification_key,
-        &proof2.revealed_messages,
-        &ver_challenge,
-    );
+    let res2 =
+        proof2
+            .proof
+            .verify(
+                &proof_request2.verification_key,
+                &proof2.revealed_messages,
+                &ver_challenge,
+            );
     match res2 {
         Ok(_) => assert!(true),   // check revealed messages
         Err(_) => assert!(false), // Why did the proof fail?

--- a/libzmix/bbs/tests/bbs.rs
+++ b/libzmix/bbs/tests/bbs.rs
@@ -433,7 +433,6 @@ fn bbs_demo() {
         Prover::commit_signature_pok(&proof_request2, proof_messages2.as_slice(), &complete_sig2)
             .unwrap();
 
-
     // Prover creates challenge_bytes and adds pok1 and pok2 to it.
     let mut chal_bytes = Vec::new();
     chal_bytes.extend_from_slice(pok1.to_bytes().as_slice());

--- a/libzmix/bbs/tests/bbs.rs
+++ b/libzmix/bbs/tests/bbs.rs
@@ -299,20 +299,11 @@ fn bbs_demo() {
     // Prover generates blind signature context and sends it to Issuer1
     // Prover stores signature blinding
     let (ctx1, signature_blinding1) =
-        Prover::new_blind_signature_context(
-            &pk1,
-            &blind_claims1,
-            &signing_nonce1
-        ).unwrap();
+        Prover::new_blind_signature_context(&pk1, &blind_claims1, &signing_nonce1).unwrap();
 
     // Issuer1 signs the credential and sends it to the Prover
-    let blind_signature1 = Issuer::blind_sign(
-        &ctx1,
-        &credential1,
-        &sk1,
-        &pk1,
-        &signing_nonce1
-    ).unwrap();
+    let blind_signature1 =
+        Issuer::blind_sign(&ctx1, &credential1, &sk1, &pk1, &signing_nonce1).unwrap();
 
     // Prover adds link secret to the credential from Issuer1
     let mut full_credential1 = credential1
@@ -322,22 +313,19 @@ fn bbs_demo() {
     full_credential1.insert(0, link_secret.clone());
 
     // Prover completes the signature from Issuer1
-    let complete_signature1 =
-        Prover::complete_signature(
-            &pk1,
-            full_credential1.as_slice(),
-            &blind_signature1,
-            &signature_blinding1);
+    let complete_signature1 = Prover::complete_signature(
+        &pk1,
+        full_credential1.as_slice(),
+        &blind_signature1,
+        &signature_blinding1,
+    );
 
     // Prover verifies the signature from Issuer1
     assert!(complete_signature1.is_ok());
     let complete_sig1 = complete_signature1.unwrap();
     assert!(complete_sig1
-        .verify(
-            full_credential1.as_slice(),
-            &pk1
-        ).unwrap()
-    );
+        .verify(full_credential1.as_slice(), &pk1)
+        .unwrap());
 
     // Issuer2 creates keys to sign a credential with 4 claims
     // (one of which is the blinded link secret)
@@ -363,20 +351,11 @@ fn bbs_demo() {
     // Prover generates blind signature context and sends it to Issuer2
     // Prover stores signature blinding
     let (ctx2, signature_blinding2) =
-        Prover::new_blind_signature_context(
-            &pk2,
-            &blind_claims2,
-            &signing_nonce2
-        ).unwrap();
+        Prover::new_blind_signature_context(&pk2, &blind_claims2, &signing_nonce2).unwrap();
 
     // Issuer2 signs the credential and sends it to the Prover
-    let blind_signature2 = Issuer::blind_sign(
-        &ctx2,
-        &credential2,
-        &sk2,
-        &pk2,
-        &signing_nonce2
-    ).unwrap();
+    let blind_signature2 =
+        Issuer::blind_sign(&ctx2, &credential2, &sk2, &pk2, &signing_nonce2).unwrap();
 
     // Prover adds link secret to the credential from Issuer2
     let mut full_credential2 = credential2
@@ -389,20 +368,19 @@ fn bbs_demo() {
     assert_eq!(full_credential1[2], full_credential2[3]);
 
     // Prover completes the signature from Issuer2
-    let complete_signature2 =
-        Prover::complete_signature(
-            &pk2,
-            full_credential2.as_slice(),
-            &blind_signature2,
-            &signature_blinding2);
+    let complete_signature2 = Prover::complete_signature(
+        &pk2,
+        full_credential2.as_slice(),
+        &blind_signature2,
+        &signature_blinding2,
+    );
 
     // Prover verifies the signature from Issuer1
     assert!(complete_signature2.is_ok());
     let complete_sig2 = complete_signature2.unwrap();
     assert!(complete_sig2
-        .verify(
-            &pk2
-    );
+        .verify(full_credential2.as_slice(), &pk2)
+        .unwrap());
 
     // Verifier wants the Prover to reveal claim1 from Issuer1,
     // plus a proof that claim2 from Issuer1 and claim3 from Issuer2 are identical
@@ -410,18 +388,10 @@ fn bbs_demo() {
     let verifier_nonce = Verifier::generate_proof_nonce();
 
     // Verifier creates proof request for the reveal of claim1 from credential1 from Issuer1
-    let proof_request1 =
-        Verifier::new_proof_request(
-            &[1],
-            &pk1
-        ).unwrap();
+    let proof_request1 = Verifier::new_proof_request(&[1], &pk1).unwrap();
 
     // Verifier creates proof request for credential2 from Issuer2
-    let proof_request2 =
-        Verifier::new_proof_request(
-            &[],
-            &pk2
-        ).unwrap();
+    let proof_request2 = Verifier::new_proof_request(&[], &pk2).unwrap();
 
     let proof_request = Verifier::new_proof_request(&[1, 3], &pk).unwrap();
     // and additionally communicates the request for a ZK equality proof of
@@ -448,14 +418,13 @@ fn bbs_demo() {
         pm_revealed!(b"claim1_first_name"),
         pm_hidden_raw!(same_claim.clone(), same_blinding.clone()),
         pm_hidden!(b"claim3_email"),
-        pm_hidden!(b"message_3"),
+        pm_hidden!(b"claim4_address"),
     ];
 
     // Prover constructs signature proof of knowledge for credential1
     let pok1 =
-            &proof_request1,
-            proof_messages1.as_slice(),
-            &complete_sig1
+        Prover::commit_signature_pok(&proof_request1, proof_messages1.as_slice(), &complete_sig1)
+            .unwrap();
 
     // Prover constructs proof messages from credential2
     // for ZK equality proof of claim3
@@ -463,15 +432,13 @@ fn bbs_demo() {
         pm_hidden_raw!(link_secret.clone(), link_secret_blinding.clone()),
         pm_hidden!(b"claim1_loyalty_program_id"),
         pm_hidden!(b"claim2_customer_id"),
+        pm_hidden_raw!(same_claim.clone(), same_blinding.clone()),
     ];
 
     // Prover constructs signature proof of knowledge for credential2
     let pok2 =
-        Prover::commit_signature_pok(
-            &proof_request2,
-            proof_messages2.as_slice(),
-            &complete_sig2
-        ).unwrap();
+        Prover::commit_signature_pok(&proof_request2, proof_messages2.as_slice(), &complete_sig2)
+            .unwrap();
 
 
     // Prover creates challenge_bytes and adds pok1 and pok2 to it.
@@ -485,14 +452,8 @@ fn bbs_demo() {
     let challenge = SignatureNonce::from_msg_hash(&chal_bytes);
 
     // Prover constructs the proofs and sends them to the Verifier
-    let proof1 = Prover::generate_signature_pok(
-        pok1,
-    let challenge =
-
-    let proof = Prover::generate_signature_pok(pok, &challenge).unwrap();
-
-    // Send `proof`, `claims`, and `challenge` to Verifier
-    ).unwrap();
+    let proof1 = Prover::generate_signature_pok(pok1, &challenge).unwrap();
+    let proof2 = Prover::generate_signature_pok(pok2, &challenge).unwrap();
 
     // Verifier creates their own challenge bytes
     // and adds proof1 and proof2 to it
@@ -501,10 +462,13 @@ fn bbs_demo() {
         &proof_request1.verification_key,
     );
     ver_chal_bytes.extend_from_slice(
-        proof2.proof.get_bytes_for_challenge(
-            proof_request2.revealed_messages.clone(),
-            &proof_request2.verification_key,
-        ).as_slice()
+        proof2
+            .proof
+            .get_bytes_for_challenge(
+                proof_request2.revealed_messages.clone(),
+                &proof_request2.verification_key,
+            )
+            .as_slice(),
     );
 
     // Verifier completes ver_challenge_bytes by adding verifier_nonce,
@@ -513,22 +477,28 @@ fn bbs_demo() {
     let ver_challenge = SignatureNonce::from_msg_hash(&ver_chal_bytes);
 
     // Verifier checks proof1
-    let res1 = proof1.proof.verify(
-        &proof_request1.verification_key,
-        &proof1.revealed_messages,
-        &ver_challenge,
-    );
+    let res1 =
+        proof1
+            .proof
+            .verify(
+                &proof_request1.verification_key,
+                &proof1.revealed_messages,
+                &ver_challenge,
+            );
     match res1 {
         Ok(_) => assert!(true),   // check revealed messages
         Err(_) => assert!(false), // Why did the proof fail?
     };
 
     // Verifier checks proof1
-    let res2 = proof2.proof.verify(
-        &proof_request2.verification_key,
-        &proof2.revealed_messages,
-        &ver_challenge,
-    );
+    let res2 =
+        proof2
+            .proof
+            .verify(
+                &proof_request2.verification_key,
+                &proof2.revealed_messages,
+                &ver_challenge,
+            );
     match res2 {
         Ok(_) => assert!(true),   // check revealed messages
         Err(_) => assert!(false), // Why did the proof fail?

--- a/libzmix/bbs/tests/bbs.rs
+++ b/libzmix/bbs/tests/bbs.rs
@@ -299,11 +299,20 @@ fn bbs_demo() {
     // Prover generates blind signature context and sends it to Issuer1
     // Prover stores signature blinding
     let (ctx1, signature_blinding1) =
-        Prover::new_blind_signature_context(&pk1, &blind_claims1, &signing_nonce1).unwrap();
+        Prover::new_blind_signature_context(
+            &pk1,
+            &blind_claims1,
+            &signing_nonce1
+        ).unwrap();
 
     // Issuer1 signs the credential and sends it to the Prover
-    let blind_signature1 =
-        Issuer::blind_sign(&ctx1, &credential1, &sk1, &pk1, &signing_nonce1).unwrap();
+    let blind_signature1 = Issuer::blind_sign(
+        &ctx1,
+        &credential1,
+        &sk1,
+        &pk1,
+        &signing_nonce1
+    ).unwrap();
 
     // Prover adds link secret to the credential from Issuer1
     let mut full_credential1 = credential1
@@ -313,19 +322,22 @@ fn bbs_demo() {
     full_credential1.insert(0, link_secret.clone());
 
     // Prover completes the signature from Issuer1
-    let complete_signature1 = Prover::complete_signature(
-        &pk1,
-        full_credential1.as_slice(),
-        &blind_signature1,
-        &signature_blinding1,
-    );
+    let complete_signature1 =
+        Prover::complete_signature(
+            &pk1,
+            full_credential1.as_slice(),
+            &blind_signature1,
+            &signature_blinding1);
 
     // Prover verifies the signature from Issuer1
     assert!(complete_signature1.is_ok());
     let complete_sig1 = complete_signature1.unwrap();
     assert!(complete_sig1
-        .verify(full_credential1.as_slice(), &pk1)
-        .unwrap());
+        .verify(
+            full_credential1.as_slice(),
+            &pk1
+        ).unwrap()
+    );
 
     // Issuer2 creates keys to sign a credential with 4 claims
     // (one of which is the blinded link secret)
@@ -351,11 +363,20 @@ fn bbs_demo() {
     // Prover generates blind signature context and sends it to Issuer2
     // Prover stores signature blinding
     let (ctx2, signature_blinding2) =
-        Prover::new_blind_signature_context(&pk2, &blind_claims2, &signing_nonce2).unwrap();
+        Prover::new_blind_signature_context(
+            &pk2,
+            &blind_claims2,
+            &signing_nonce2
+        ).unwrap();
 
     // Issuer2 signs the credential and sends it to the Prover
-    let blind_signature2 =
-        Issuer::blind_sign(&ctx2, &credential2, &sk2, &pk2, &signing_nonce2).unwrap();
+    let blind_signature2 = Issuer::blind_sign(
+        &ctx2,
+        &credential2,
+        &sk2,
+        &pk2,
+        &signing_nonce2
+    ).unwrap();
 
     // Prover adds link secret to the credential from Issuer2
     let mut full_credential2 = credential2
@@ -368,19 +389,20 @@ fn bbs_demo() {
     assert_eq!(full_credential1[2], full_credential2[3]);
 
     // Prover completes the signature from Issuer2
-    let complete_signature2 = Prover::complete_signature(
-        &pk2,
-        full_credential2.as_slice(),
-        &blind_signature2,
-        &signature_blinding2,
-    );
+    let complete_signature2 =
+        Prover::complete_signature(
+            &pk2,
+            full_credential2.as_slice(),
+            &blind_signature2,
+            &signature_blinding2);
 
     // Prover verifies the signature from Issuer1
     assert!(complete_signature2.is_ok());
     let complete_sig2 = complete_signature2.unwrap();
     assert!(complete_sig2
-        .verify(full_credential2.as_slice(), &pk2)
-        .unwrap());
+        .verify(
+            &pk2
+    );
 
     // Verifier wants the Prover to reveal claim1 from Issuer1,
     // plus a proof that claim2 from Issuer1 and claim3 from Issuer2 are identical
@@ -388,7 +410,22 @@ fn bbs_demo() {
     let verifier_nonce = Verifier::generate_proof_nonce();
 
     // Verifier creates proof request for the reveal of claim1 from credential1 from Issuer1
-    let proof_request1 = Verifier::new_proof_request(&[1], &pk1).unwrap();
+    let proof_request1 =
+        Verifier::new_proof_request(
+            &[1],
+            &pk1
+        ).unwrap();
+
+    // Verifier creates proof request for credential2 from Issuer2
+    let proof_request2 =
+        Verifier::new_proof_request(
+            &[],
+            &pk2
+        ).unwrap();
+
+    let proof_request = Verifier::new_proof_request(&[1, 3], &pk).unwrap();
+    // and additionally communicates the request for a ZK equality proof of
+    // claim2 from credential1 and claim3 from credential2.
 
     // Verifier creates proof request for credential2 from Issuer2
     let proof_request2 = Verifier::new_proof_request(&[], &pk2).unwrap();
@@ -411,13 +448,14 @@ fn bbs_demo() {
         pm_revealed!(b"claim1_first_name"),
         pm_hidden_raw!(same_claim.clone(), same_blinding.clone()),
         pm_hidden!(b"claim3_email"),
-        pm_hidden!(b"claim4_address"),
+        pm_hidden!(b"message_3"),
     ];
 
     // Prover constructs signature proof of knowledge for credential1
     let pok1 =
-        Prover::commit_signature_pok(&proof_request1, proof_messages1.as_slice(), &complete_sig1)
-            .unwrap();
+            &proof_request1,
+            proof_messages1.as_slice(),
+            &complete_sig1
 
     // Prover constructs proof messages from credential2
     // for ZK equality proof of claim3
@@ -425,13 +463,16 @@ fn bbs_demo() {
         pm_hidden_raw!(link_secret.clone(), link_secret_blinding.clone()),
         pm_hidden!(b"claim1_loyalty_program_id"),
         pm_hidden!(b"claim2_customer_id"),
-        pm_hidden_raw!(same_claim.clone(), same_blinding.clone()),
     ];
 
     // Prover constructs signature proof of knowledge for credential2
     let pok2 =
-        Prover::commit_signature_pok(&proof_request2, proof_messages2.as_slice(), &complete_sig2)
-            .unwrap();
+        Prover::commit_signature_pok(
+            &proof_request2,
+            proof_messages2.as_slice(),
+            &complete_sig2
+        ).unwrap();
+
 
     // Prover creates challenge_bytes and adds pok1 and pok2 to it.
     let mut chal_bytes = Vec::new();
@@ -444,8 +485,14 @@ fn bbs_demo() {
     let challenge = SignatureNonce::from_msg_hash(&chal_bytes);
 
     // Prover constructs the proofs and sends them to the Verifier
-    let proof1 = Prover::generate_signature_pok(pok1, &challenge).unwrap();
-    let proof2 = Prover::generate_signature_pok(pok2, &challenge).unwrap();
+    let proof1 = Prover::generate_signature_pok(
+        pok1,
+    let challenge =
+
+    let proof = Prover::generate_signature_pok(pok, &challenge).unwrap();
+
+    // Send `proof`, `claims`, and `challenge` to Verifier
+    ).unwrap();
 
     // Verifier creates their own challenge bytes
     // and adds proof1 and proof2 to it
@@ -454,17 +501,15 @@ fn bbs_demo() {
         &proof_request1.verification_key,
     );
     ver_chal_bytes.extend_from_slice(
-        proof2
-            .proof
-            .get_bytes_for_challenge(
-                proof_request2.revealed_messages.clone(),
-                &proof_request2.verification_key,
-            )
-            .as_slice(),
+        proof2.proof.get_bytes_for_challenge(
+            proof_request2.revealed_messages.clone(),
+            &proof_request2.verification_key,
+        ).as_slice()
     );
 
     // Verifier completes ver_challenge_bytes by adding verifier_nonce,
     // then constructs the challenge
+    ver_chal_bytes.extend_from_slice(&verifier_nonce.to_bytes()[..]);
     let ver_challenge = SignatureNonce::from_msg_hash(&ver_chal_bytes);
 
     // Verifier checks proof1
@@ -473,7 +518,7 @@ fn bbs_demo() {
         &proof1.revealed_messages,
         &ver_challenge,
     );
-    match res1 {
+    match res1{
         Ok(_) => assert!(true),   // check revealed messages
         Err(_) => assert!(false), // Why did the proof fail?
     };
@@ -484,7 +529,7 @@ fn bbs_demo() {
         &proof2.revealed_messages,
         &ver_challenge,
     );
-    match res2 {
+    match res2{
         Ok(_) => assert!(true),   // check revealed messages
         Err(_) => assert!(false), // Why did the proof fail?
     };

--- a/libzmix/bbs/tests/bbs.rs
+++ b/libzmix/bbs/tests/bbs.rs
@@ -397,13 +397,6 @@ fn bbs_demo() {
     // and additionally communicates the request for a ZK equality proof of
     // claim2 from credential1 and claim3 from credential2.
 
-    // Verifier creates proof request for credential2 from Issuer2
-    let proof_request2 = Verifier::new_proof_request(&[], &pk2).unwrap();
-
-    // Verifier sends verifier_nonce, proof_request1, and proof_request2 to Prover
-    // and additionally communicates the request for a ZK equality proof of
-    // claim2 from credential1 and claim3 from credential2.
-
     // Prover creates a blinding factor to use for his link secrets.
     let link_secret_blinding = SignatureNonce::random();
 

--- a/libzmix/bbs/tests/bbs.rs
+++ b/libzmix/bbs/tests/bbs.rs
@@ -469,28 +469,22 @@ fn bbs_demo() {
     let ver_challenge = SignatureNonce::from_msg_hash(&ver_chal_bytes);
 
     // Verifier checks proof1
-    let res1 =
-        proof1
-            .proof
-            .verify(
-                &proof_request1.verification_key,
-                &proof1.revealed_messages,
-                &ver_challenge,
-            );
+    let res1 = proof1.proof.verify(
+        &proof_request1.verification_key,
+        &proof1.revealed_messages,
+        &ver_challenge,
+    );
     match res1 {
         Ok(_) => assert!(true),   // check revealed messages
         Err(_) => assert!(false), // Why did the proof fail?
     };
 
     // Verifier checks proof1
-    let res2 =
-        proof2
-            .proof
-            .verify(
-                &proof_request2.verification_key,
-                &proof2.revealed_messages,
-                &ver_challenge,
-            );
+    let res2 = proof2.proof.verify(
+        &proof_request2.verification_key,
+        &proof2.revealed_messages,
+        &ver_challenge,
+    );
     match res2 {
         Ok(_) => assert!(true),   // check revealed messages
         Err(_) => assert!(false), // Why did the proof fail?

--- a/libzmix/bbs/tests/bbs.rs
+++ b/libzmix/bbs/tests/bbs.rs
@@ -518,7 +518,7 @@ fn bbs_demo() {
         &proof1.revealed_messages,
         &ver_challenge,
     );
-    match res1{
+    match res1 {
         Ok(_) => assert!(true),   // check revealed messages
         Err(_) => assert!(false), // Why did the proof fail?
     };
@@ -529,7 +529,7 @@ fn bbs_demo() {
         &proof2.revealed_messages,
         &ver_challenge,
     );
-    match res2{
+    match res2 {
         Ok(_) => assert!(true),   // check revealed messages
         Err(_) => assert!(false), // Why did the proof fail?
     };

--- a/libzmix/bbs/tests/bbs.rs
+++ b/libzmix/bbs/tests/bbs.rs
@@ -440,7 +440,6 @@ fn bbs_demo() {
         Prover::commit_signature_pok(&proof_request2, proof_messages2.as_slice(), &complete_sig2)
             .unwrap();
 
-
     // Prover creates challenge_bytes and adds pok1 and pok2 to it.
     let mut chal_bytes = Vec::new();
     chal_bytes.extend_from_slice(pok1.to_bytes().as_slice());

--- a/libzmix/bbs/tests/bbs.rs
+++ b/libzmix/bbs/tests/bbs.rs
@@ -461,7 +461,6 @@ fn bbs_demo() {
     // Verifier creates proof request for credential2 from Issuer2
     let proof_request2 = Verifier::new_proof_request(&[], &pk2).unwrap();
 
-    let proof_request = Verifier::new_proof_request(&[1, 3], &pk).unwrap();
     // and additionally communicates the request for a ZK equality proof of
     // claim2 from credential1 and claim3 from credential2.
 


### PR DESCRIPTION
Adds a demo of the full flow of credentials using bbs+ signatures.
A Prover obtains credentials from two Issuers that include the Prover's link secret.
A Verifier requests that the Prover reveal one claim from one credential, and prove the equality of one claim from each credential.