### PR TITLE
Update to use pairing_plus vs milagro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,12 +76,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee5cca1ddc8b9dceb55b7f1272a9d1e643d73006f350a20ab4926d24e33f0f0d"
 
 [[package]]
-name = "amcl-milagro"
-version = "3.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a7f1be21d1876ce01fe62e2984fd4617fccc251f17d25098e869fd83f71e770"
-
-[[package]]
 name = "amcl_wrapper"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,27 +89,6 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sha3",
- "subtle-encoding",
- "zeroize",
-]
-
-[[package]]
-name = "amcl_wrapper_ml"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e42a488f50de1a3614f6ee9684c973b70634a03c4873da0141c0e53632677410"
-dependencies = [
- "amcl-milagro",
- "arrayref",
- "byteorder",
- "hash2curve",
- "lazy_static",
- "rand 0.7.3",
- "rayon",
- "serde",
- "serde_json",
- "sha2",
  "sha3",
  "subtle-encoding",
  "zeroize",
@@ -183,18 +156,19 @@ dependencies = [
 
 [[package]]
 name = "bbs"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
- "amcl_wrapper_ml",
  "arrayref",
+ "blake2",
  "failure",
- "hash2curve",
+ "ff-zeroize",
  "hex",
  "hkdf",
+ "pairing-plus",
  "rand 0.7.3",
  "rayon",
  "serde",
- "sha2",
+ "zeroize",
 ]
 
 [[package]]
@@ -705,6 +679,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
+name = "ff-zeroize"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c02169a2e8515aa316ce516eaaf6318a76617839fbf904073284bc2576b029ee"
+dependencies = [
+ "byteorder",
+ "ff_derive-zeroize",
+ "rand_core 0.5.1",
+ "zeroize",
+]
+
+[[package]]
+name = "ff_derive-zeroize"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b24d4059bc0d0a0bf26b740aa21af1f96a984f0ab7a21356d00b32475388b53a"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "ffi-support"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -806,21 +806,6 @@ name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
-
-[[package]]
-name = "hash2curve"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2a6bd19dc0e3fd7a8c1082a5ae48c33f3ef1492c4780f541e1686c6e1e174d8"
-dependencies = [
- "amcl-milagro",
- "arrayref",
- "digest",
- "failure",
- "sha2",
- "subtle 2.2.2",
- "subtle-encoding",
-]
 
 [[package]]
 name = "hermit-abi"
@@ -1148,6 +1133,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "pairing-plus"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58cda4f22e8e6720f3c254049960c8cc4f93cb82b5ade43bddd2622b5f39ea62"
+dependencies = [
+ "byteorder",
+ "digest",
+ "ff-zeroize",
+ "rand 0.4.6",
+ "rand_core 0.5.1",
+ "rand_xorshift 0.2.0",
+ "zeroize",
+]
+
+[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1228,6 +1228,19 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c618c47cd3ebd209790115ab837de41425723956ad3ce2e6a7f09890947cacb9"
@@ -1254,7 +1267,7 @@ dependencies = [
  "rand_jitter",
  "rand_os",
  "rand_pcg",
- "rand_xorshift",
+ "rand_xorshift 0.1.1",
  "winapi",
 ]
 
@@ -1385,6 +1398,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 dependencies = [
  "rand_core 0.3.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77d416b86801d23dde1aa643023b775c3a462efc0ed96443add11546cdf1dca8"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]

--- a/libzmix/Cargo.toml
+++ b/libzmix/Cargo.toml
@@ -22,7 +22,7 @@ PS_Signature_G1 = []
 [dependencies]
 arrayref = "0.3.6"
 bulletproofs_amcl = { version = "0.2.0", path = "./bulletproofs_amcl" }
-bbs =  { version = "0.3.0", path = "./bbs", optional = true }
+bbs =  { version = "0.4.0", path = "./bbs", optional = true }
 criterion = "0.3"
 failure = "0.1"
 lazy_static = "1.4"

--- a/libzmix/bbs/Cargo.toml
+++ b/libzmix/bbs/Cargo.toml
@@ -12,6 +12,9 @@ version = "0.4.0"
 [badges]
 maintenance = { status = "active" }
 
+[features]
+default = ["rayon"]
+
 [dependencies]
 arrayref = "0.3"
 blake2 = "0.8"
@@ -19,7 +22,7 @@ failure = "0.1"
 ff-zeroize = "0.6"
 hex = "0.4"
 hkdf = "0.8"
-rayon = "1.3"
+rayon = { version = "1.3", optional = true }
 rand = "0.7"
 pairing-plus = "0.19"
 serde = { version = "1.0", features = ["serde_derive"] }

--- a/libzmix/bbs/Cargo.toml
+++ b/libzmix/bbs/Cargo.toml
@@ -7,21 +7,22 @@ license = "Apache-2.0"
 name = "bbs"
 readme = "README.md"
 repository = "https://github.com/hyperledger/ursa"
-version = "0.3.0"
+version = "0.4.0"
 
 [badges]
 maintenance = { status = "active" }
 
 [dependencies]
-amcl_wrapper = { version = "0.5", default-features = false, features = ["bls381"], package = "amcl_wrapper_ml" }
 arrayref = "0.3"
+blake2 = "0.8"
 failure = "0.1"
-hash2curve = { version = "0.0.6", features = ["bls"] }
-hkdf = "0.8.0"
-rayon = "1.3.0"
-rand = "0.7.3"
-sha2 = "0.8"
+ff-zeroize = "0.6"
+hex = "0.4"
+hkdf = "0.8"
+rayon = "1.3"
+rand = "0.7"
+pairing-plus = "0.19"
 serde = { version = "1.0", features = ["serde_derive"] }
+zeroize = "1.1"
 
 [dev-dependencies]
-hex = "0.4.2"

--- a/libzmix/bbs/README.md
+++ b/libzmix/bbs/README.md
@@ -12,7 +12,7 @@ and selective disclosure zero-knowledge proofs. To start, all that is needed is 
 
 ```toml
 [dependencies]
-bbs = "0.2"
+bbs = "0.4"
 ```
 
 Add in the main section of code to get all the traits, structs, and functions needed.
@@ -44,8 +44,7 @@ or
 
 ```rust
 let (dpk, sk) = Issuer::new_short_keys(None);
-let dst = DomainSeparationTag::new("testgen", None, None, None).unwrap();
-let pk = dpk.to_public_key(5, dst).unwrap();
+let pk = dpk.to_public_key(5).unwrap();
 ```
 
 ## Signing
@@ -58,11 +57,11 @@ To create a signature:
 ```rust
 let (pk, sk) = Issuer::new_keys(5).unwrap();
 let messages = vec![
-    SignatureMessage::from_msg_hash(b"message 1"),
-    SignatureMessage::from_msg_hash(b"message 2"),
-    SignatureMessage::from_msg_hash(b"message 3"),
-    SignatureMessage::from_msg_hash(b"message 4"),
-    SignatureMessage::from_msg_hash(b"message 5"),
+    SignatureMessage::hash(b"message 1"),
+    SignatureMessage::hash(b"message 2"),
+    SignatureMessage::hash(b"message 3"),
+    SignatureMessage::hash(b"message 4"),
+    SignatureMessage::hash(b"message 5"),
 ];
 
 let signature = Signature::new(messages.as_slice(), &sk, &pk).unwrap();
@@ -78,7 +77,7 @@ let (pk, sk) = Issuer::new_keys(5).unwrap();
 
 // Done by the signature recipient
 
-let message = SignatureMessage::from_msg_hash(b"message_0");
+let message = SignatureMessage::hash(b"message_0");
 
 let signature_blinding = Signature::generate_blinding();
 
@@ -175,11 +174,11 @@ The Verifier must trust the signer of the credential and know the message struct
 ```rust
 let (pk, sk) = Issuer::new_keys(5).unwrap();
 let messages = vec![
-    SignatureMessage::from_msg_hash(b"message_1"),
-    SignatureMessage::from_msg_hash(b"message_2"),
-    SignatureMessage::from_msg_hash(b"message_3"),
-    SignatureMessage::from_msg_hash(b"message_4"),
-    SignatureMessage::from_msg_hash(b"message_5"),
+    SignatureMessage::hash(b"message_1"),
+    SignatureMessage::hash(b"message_2"),
+    SignatureMessage::hash(b"message_3"),
+    SignatureMessage::hash(b"message_4"),
+    SignatureMessage::hash(b"message_5"),
 ];
 
 let signature = Signature::new(messages.as_slice(), &sk, &pk).unwrap();
@@ -206,7 +205,7 @@ let mut challenge_bytes = Vec::new();
 challenge_bytes.extend_from_slice(pok.to_bytes().as_slice());
 challenge_bytes.extend_from_slice(nonce.to_bytes().as_slice());
 
-let challenge = SignatureNonce::from_msg_hash(&challenge_bytes);
+let challenge = ProofNonce::hash(&challenge_bytes);
 
 let proof = Prover::generate_signature_pok(pok, &challenge).unwrap();
 

--- a/libzmix/bbs/src/issuer.rs
+++ b/libzmix/bbs/src/issuer.rs
@@ -9,7 +9,7 @@ use crate::signature::prelude::*;
 /// `PublicKey` later. The latter is primarily used for storing a shorter
 /// key and looks just like a regular ECC key.
 use crate::{BlindSignatureContext, ProofNonce, RandomElem, SignatureMessage};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 /// This struct represents an Issuer of signatures or Signer.
 /// Provided are methods for signing regularly where all messages are known
@@ -45,7 +45,8 @@ impl Issuer {
         verkey: &PublicKey,
         nonce: &ProofNonce,
     ) -> Result<BlindSignature, BBSError> {
-        if ctx.verify(messages, verkey, nonce)? {
+        let revealed_messages: BTreeSet<usize> = messages.keys().map(|i| *i).collect();
+        if ctx.verify(&revealed_messages, verkey, nonce)? {
             BlindSignature::new(&ctx.commitment, messages, signkey, verkey)
         } else {
             Err(BBSErrorKind::GeneralError {

--- a/libzmix/bbs/src/issuer.rs
+++ b/libzmix/bbs/src/issuer.rs
@@ -1,3 +1,6 @@
+use crate::errors::prelude::*;
+use crate::keys::prelude::*;
+use crate::signature::prelude::*;
 /// The issuer generates keys and uses those to sign
 /// credentials. There are two types of public keys:
 /// `PublicKey` which generates all generators at random and
@@ -5,7 +8,7 @@
 /// to the secret key. `DeterministicPublicKey` can be converted to a
 /// `PublicKey` later. The latter is primarily used for storing a shorter
 /// key and looks just like a regular ECC key.
-use crate::prelude::*;
+use crate::{BlindSignatureContext, ProofNonce, RandomElem, SignatureMessage};
 use std::collections::BTreeMap;
 
 /// This struct represents an Issuer of signatures or Signer.
@@ -40,7 +43,7 @@ impl Issuer {
         messages: &BTreeMap<usize, SignatureMessage>,
         signkey: &SecretKey,
         verkey: &PublicKey,
-        nonce: &SignatureNonce,
+        nonce: &ProofNonce,
     ) -> Result<BlindSignature, BBSError> {
         if ctx.verify(messages, verkey, nonce)? {
             BlindSignature::new(&ctx.commitment, messages, signkey, verkey)
@@ -53,7 +56,7 @@ impl Issuer {
     }
 
     /// Create a nonce used for the blind signing context
-    pub fn generate_signing_nonce() -> SignatureNonce {
-        SignatureNonce::random()
+    pub fn generate_signing_nonce() -> ProofNonce {
+        ProofNonce::random()
     }
 }

--- a/libzmix/bbs/src/keys.rs
+++ b/libzmix/bbs/src/keys.rs
@@ -28,7 +28,7 @@ use zeroize::Zeroize;
 pub mod prelude {
     pub use super::{
         generate, DeterministicPublicKey, KeyGenOption, PublicKey, SecretKey,
-        COMPRESSED_DETERMINISTIC_PUBLIC_KEY_SIZE,
+        DETERMINISTIC_PUBLIC_KEY_COMPRESSED_SIZE,
     };
 }
 
@@ -166,7 +166,7 @@ display_impl!(PublicKey);
 serdes_impl!(PublicKey);
 
 /// Size of a compressed deterministic public key
-pub const COMPRESSED_DETERMINISTIC_PUBLIC_KEY_SIZE: usize = G2_COMPRESSED_SIZE;
+pub const DETERMINISTIC_PUBLIC_KEY_COMPRESSED_SIZE: usize = G2_COMPRESSED_SIZE;
 
 /// Used to deterministically generate all other generators given a commitment to a private key
 /// This is effectively a BLS signature public key

--- a/libzmix/bbs/src/lib.rs
+++ b/libzmix/bbs/src/lib.rs
@@ -741,6 +741,11 @@ pub mod prelude {
         ProofChallenge,
         ProofNonce,
         ProofRequest,
+        FR_COMPRESSED_SIZE,
+        G1_COMPRESSED_SIZE,
+        G1_UNCOMPRESSED_SIZE,
+        G2_COMPRESSED_SIZE,
+        G2_UNCOMPRESSED_SIZE
     };
 }
 

--- a/libzmix/bbs/src/lib.rs
+++ b/libzmix/bbs/src/lib.rs
@@ -139,53 +139,28 @@ impl Commitment {
         Commitment(multi_scalar_mul_const_time_g1(bases, scalars))
     }
 
-    to_fixed_length_bytes_impl!(
-        Commitment,
-        G1,
-        G1_COMPRESSED_SIZE,
-        G1_UNCOMPRESSED_SIZE
-    );
+    to_fixed_length_bytes_impl!(Commitment, G1, G1_COMPRESSED_SIZE, G1_UNCOMPRESSED_SIZE);
 }
 
 as_ref_impl!(Commitment, G1);
-from_impl!(
-    Commitment,
-    G1,
-    G1_COMPRESSED_SIZE,
-    G1_UNCOMPRESSED_SIZE
-);
+from_impl!(Commitment, G1, G1_COMPRESSED_SIZE, G1_UNCOMPRESSED_SIZE);
 display_impl!(Commitment);
 serdes_impl!(Commitment);
-hash_elem_impl!(Commitment, |data| {
-    Commitment(hash_to_g1(data))
-});
+hash_elem_impl!(Commitment, |data| { Commitment(hash_to_g1(data)) });
 
 /// Wrapper for G1
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub struct GeneratorG1(pub(crate) G1);
 
 impl GeneratorG1 {
-
-    to_fixed_length_bytes_impl!(
-        GeneratorG1,
-        G1,
-        G1_COMPRESSED_SIZE,
-        G1_UNCOMPRESSED_SIZE
-    );
+    to_fixed_length_bytes_impl!(GeneratorG1, G1, G1_COMPRESSED_SIZE, G1_UNCOMPRESSED_SIZE);
 }
 
 as_ref_impl!(GeneratorG1, G1);
-from_impl!(
-    GeneratorG1,
-    G1,
-    G1_COMPRESSED_SIZE,
-    G1_UNCOMPRESSED_SIZE
-);
+from_impl!(GeneratorG1, G1, G1_COMPRESSED_SIZE, G1_UNCOMPRESSED_SIZE);
 display_impl!(GeneratorG1);
 serdes_impl!(GeneratorG1);
-hash_elem_impl!(GeneratorG1, |data| {
-    GeneratorG1(hash_to_g1(data))
-});
+hash_elem_impl!(GeneratorG1, |data| { GeneratorG1(hash_to_g1(data)) });
 random_elem_impl!(GeneratorG1, { Self(G1::random(&mut thread_rng())) });
 
 /// Wrapper for G2
@@ -193,33 +168,20 @@ random_elem_impl!(GeneratorG1, { Self(G1::random(&mut thread_rng())) });
 pub struct GeneratorG2(pub(crate) G2);
 
 impl GeneratorG2 {
-
-    to_fixed_length_bytes_impl!(
-        GeneratorG2,
-        G2,
-        G2_COMPRESSED_SIZE,
-        G2_UNCOMPRESSED_SIZE
-    );
+    to_fixed_length_bytes_impl!(GeneratorG2, G2, G2_COMPRESSED_SIZE, G2_UNCOMPRESSED_SIZE);
 }
 
 as_ref_impl!(GeneratorG2, G2);
-from_impl!(
-    GeneratorG2,
-    G2,
-    G2_COMPRESSED_SIZE,
-    G2_UNCOMPRESSED_SIZE
-);
+from_impl!(GeneratorG2, G2, G2_COMPRESSED_SIZE, G2_UNCOMPRESSED_SIZE);
 display_impl!(GeneratorG2);
 serdes_impl!(GeneratorG2);
-hash_elem_impl!(GeneratorG2, |data| {
-    GeneratorG2(hash_to_g2(data))
-});
+hash_elem_impl!(GeneratorG2, |data| { GeneratorG2(hash_to_g2(data)) });
 
 /// Convenience wrapper for creating commitments
 #[derive(Clone, Debug)]
 pub struct CommitmentBuilder {
     bases: Vec<G1>,
-    scalars: Vec<Fr>
+    scalars: Vec<Fr>,
 }
 
 impl CommitmentBuilder {
@@ -227,7 +189,7 @@ impl CommitmentBuilder {
     pub fn new() -> Self {
         Self {
             bases: Vec::new(),
-            scalars: Vec::new()
+            scalars: Vec::new(),
         }
     }
 
@@ -411,13 +373,11 @@ impl BlindSignatureContext {
             )));
         }
 
-        let commitment = Commitment(
-            slice_to_elem!(&mut cursor, G1, compressed).map_err(|e| {
-                BBSError::from_kind(BBSErrorKind::PoKVCError {
-                    msg: format!("{}", e),
-                })
-            })?,
-        );
+        let commitment = Commitment(slice_to_elem!(&mut cursor, G1, compressed).map_err(|e| {
+            BBSError::from_kind(BBSErrorKind::PoKVCError {
+                msg: format!("{}", e),
+            })
+        })?);
 
         let end = g1_size + FR_COMPRESSED_SIZE;
 
@@ -475,7 +435,9 @@ impl BlindSignatureContext {
         let mut challenge = SignatureMessage::hash(&challenge_bytes);
         challenge.0.sub_assign(&self.challenge_hash.0);
 
-        commitment.0.sub_assign(&self.proof_of_hidden_messages.commitment);
+        commitment
+            .0
+            .sub_assign(&self.proof_of_hidden_messages.commitment);
 
         Ok(commitment.0.is_zero() && challenge.0.is_zero())
     }
@@ -718,44 +680,25 @@ fn bitvector_to_revealed(data: &[u8]) -> BTreeSet<usize> {
 /// Convenience importer
 pub mod prelude {
     pub use super::{
-        errors::prelude::*,
-        keys::prelude::*,
-        messages::*,
-        signature::prelude::*,
-        pok_sig::prelude::*,
-        pok_vc::prelude::*,
-        issuer::Issuer,
-        prover::Prover,
-        verifier::Verifier,
-        Commitment,
-        CommitmentBuilder,
-        GeneratorG1,
-        GeneratorG2,
-        BlindSignatureContext,
-        ToVariableLengthBytes,
-        RandomElem,
-        HashElem,
-        SignatureMessage,
-        SignatureBlinding,
-        SignatureProof,
-        ProofChallenge,
-        ProofNonce,
-        ProofRequest,
-        FR_COMPRESSED_SIZE,
-        G1_COMPRESSED_SIZE,
-        G1_UNCOMPRESSED_SIZE,
-        G2_COMPRESSED_SIZE,
-        G2_UNCOMPRESSED_SIZE
+        errors::prelude::*, issuer::Issuer, keys::prelude::*, messages::*, pok_sig::prelude::*,
+        pok_vc::prelude::*, prover::Prover, signature::prelude::*, verifier::Verifier,
+        BlindSignatureContext, Commitment, CommitmentBuilder, GeneratorG1, GeneratorG2, HashElem,
+        ProofChallenge, ProofNonce, ProofRequest, RandomElem, SignatureBlinding, SignatureMessage,
+        SignatureProof, ToVariableLengthBytes, FR_COMPRESSED_SIZE, G1_COMPRESSED_SIZE,
+        G1_UNCOMPRESSED_SIZE, G2_COMPRESSED_SIZE, G2_UNCOMPRESSED_SIZE,
     };
 }
 
 #[cfg(test)]
 mod tests {
     use crate::prelude::*;
-    use pairing_plus::{CurveProjective, bls12_381::{G1, Fr}};
-    use std::collections::BTreeMap;
-    use rand::thread_rng;
     use ff_zeroize::Field;
+    use pairing_plus::{
+        bls12_381::{Fr, G1},
+        CurveProjective,
+    };
+    use rand::thread_rng;
+    use std::collections::BTreeMap;
 
     #[ignore]
     #[test]
@@ -766,7 +709,7 @@ mod tests {
         let mut rng = thread_rng();
         //
         for _ in 0..count {
-        //     bases.push(G1::random(&mut rng));
+            //     bases.push(G1::random(&mut rng));
             scalars.push(Fr::random(&mut rng));
         }
         let start = std::time::Instant::now();
@@ -788,7 +731,6 @@ mod tests {
         let start = std::time::Instant::now();
         let _ = dpk.to_public_key(count);
         println!("to_public_key = {:?}", std::time::Instant::now() - start);
-
     }
 
     #[test]
@@ -825,7 +767,11 @@ mod tests {
             challenge_hash: ProofChallenge::random(),
             proof_of_hidden_messages: ProofG1 {
                 commitment: G1::one(),
-                responses: (0..10).collect::<Vec<usize>>().iter().map(|_| SignatureMessage::random().0).collect(),
+                responses: (0..10)
+                    .collect::<Vec<usize>>()
+                    .iter()
+                    .map(|_| SignatureMessage::random().0)
+                    .collect(),
             },
         };
 

--- a/libzmix/bbs/src/lib.rs
+++ b/libzmix/bbs/src/lib.rs
@@ -420,7 +420,7 @@ impl BlindSignatureContext {
     /// way
     pub fn verify(
         &self,
-        messages: &BTreeMap<usize, SignatureMessage>,
+        revealed_messages: &BTreeSet<usize>,
         verkey: &PublicKey,
         nonce: &ProofNonce,
     ) -> Result<bool, BBSError> {
@@ -429,7 +429,7 @@ impl BlindSignatureContext {
         let mut bases = Vec::new();
         bases.push(verkey.h0.clone());
         for i in 0..verkey.message_count() {
-            if !messages.contains_key(&i) {
+            if !revealed_messages.contains(&i) {
                 bases.push(verkey.h[i].clone());
             }
         }

--- a/libzmix/bbs/src/macros.rs
+++ b/libzmix/bbs/src/macros.rs
@@ -234,4 +234,3 @@ macro_rules! as_ref_impl {
         }
     };
 }
-

--- a/libzmix/bbs/src/macros.rs
+++ b/libzmix/bbs/src/macros.rs
@@ -1,0 +1,237 @@
+macro_rules! slice_to_elem {
+    ($data:expr, $elem:ident, $compressed:expr) => {{
+        use pairing_plus::{bls12_381::$elem, serdes::SerDes};
+        $elem::deserialize($data, $compressed)
+    }};
+}
+
+macro_rules! from_impl {
+    ($name:ident, $type:ident, $size:expr) => {
+        impl TryFrom<Vec<u8>> for $name {
+            type Error = BBSError;
+
+            fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+                Self::try_from(value.as_slice())
+            }
+        }
+
+        impl TryFrom<&[u8]> for $name {
+            type Error = BBSError;
+
+            fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+                let mut value = value;
+                let inner = $type::deserialize(&mut value, true).map_err(|e| {
+                    BBSErrorKind::GeneralError {
+                        msg: format!("{:?}", e),
+                    }
+                })?;
+                Ok(Self(inner))
+            }
+        }
+
+        impl From<[u8; $size]> for $name {
+            fn from(data: [u8; $size]) -> Self {
+                Self::from(&data)
+            }
+        }
+
+        impl From<&[u8; $size]> for $name {
+            fn from(data: &[u8; $size]) -> Self {
+                Self($type::deserialize(&mut data.as_ref(), true).unwrap())
+            }
+        }
+
+        impl From<$type> for $name {
+            fn from(src: $type) -> Self {
+                Self(src.clone())
+            }
+        }
+
+        impl From<&$type> for $name {
+            fn from(src: &$type) -> Self {
+                Self(src.clone())
+            }
+        }
+    };
+
+    ($name:ident, $type:ident, $comp_size:expr,$uncomp_size:expr) => {
+        impl TryFrom<Vec<u8>> for $name {
+            type Error = BBSError;
+
+            fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+                Self::try_from(value.as_slice())
+            }
+        }
+
+        impl TryFrom<&[u8]> for $name {
+            type Error = BBSError;
+
+            fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+                let inner = $type::deserialize(&mut value.as_ref(), value.len() == $comp_size)
+                    .map_err(|_| BBSErrorKind::GeneralError {
+                        msg: "Invalid bytes".to_string(),
+                    })?;
+                Ok(Self(inner))
+            }
+        }
+
+        impl From<[u8; $comp_size]> for $name {
+            fn from(data: [u8; $comp_size]) -> Self {
+                Self::from(&data)
+            }
+        }
+
+        impl From<&[u8; $comp_size]> for $name {
+            fn from(data: &[u8; $comp_size]) -> Self {
+                Self($type::deserialize(&mut data.as_ref(), true).unwrap())
+            }
+        }
+
+        impl From<[u8; $uncomp_size]> for $name {
+            fn from(data: [u8; $uncomp_size]) -> Self {
+                Self::from(&data)
+            }
+        }
+
+        impl From<&[u8; $uncomp_size]> for $name {
+            fn from(data: &[u8; $uncomp_size]) -> Self {
+                Self($type::deserialize(&mut data.as_ref(), false).unwrap())
+            }
+        }
+
+        impl From<$type> for $name {
+            fn from(src: $type) -> Self {
+                Self(src)
+            }
+        }
+
+        impl From<&$type> for $name {
+            fn from(src: &$type) -> Self {
+                Self(src.clone())
+            }
+        }
+    };
+}
+
+macro_rules! try_from_impl {
+    ($name:ident, $error:ident) => {
+        impl TryFrom<&[u8]> for $name {
+            type Error = $error;
+
+            fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
+                Self::from_bytes_compressed_form(value)
+            }
+        }
+
+        impl TryFrom<Vec<u8>> for $name {
+            type Error = $error;
+
+            fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+                Self::from_bytes_compressed_form(value)
+            }
+        }
+    };
+}
+
+macro_rules! display_impl {
+    ($name:ident) => {
+        impl Display for $name {
+            fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+                let bytes = self.to_bytes_uncompressed_form();
+                write!(f, "{} {{ {} }}", stringify!($name), hex::encode(&bytes[..]))
+            }
+        }
+    };
+}
+
+macro_rules! serdes_impl {
+    ($name:ident) => {
+        impl Serialize for $name {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                serializer.serialize_bytes(&self.to_bytes_compressed_form()[..])
+            }
+        }
+
+        impl<'a> Deserialize<'a> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'a>,
+            {
+                struct DeserializeVisitor;
+
+                impl<'a> Visitor<'a> for DeserializeVisitor {
+                    type Value = $name;
+
+                    fn expecting(&self, formatter: &mut Formatter) -> std::fmt::Result {
+                        formatter.write_str("expected byte array")
+                    }
+
+                    fn visit_bytes<E>(self, value: &[u8]) -> Result<$name, E>
+                    where
+                        E: DError,
+                    {
+                        $name::try_from(value).map_err(|_| {
+                            DError::invalid_value(serde::de::Unexpected::Bytes(value), &self)
+                        })
+                    }
+                }
+
+                deserializer.deserialize_bytes(DeserializeVisitor)
+            }
+        }
+    };
+}
+
+macro_rules! to_fixed_length_bytes_impl {
+    ($name:ident, $type:ident, $compressed:expr, $uncompressed:expr) => {
+        /// Convert to raw bytes compressed form
+        pub fn to_bytes_compressed_form(&self) -> [u8; $compressed] {
+            let mut o = [0u8; $compressed];
+            self.0.serialize(&mut o[..].as_mut(), true).unwrap();
+            o
+        }
+
+        /// Convert to raw bytes uncompressed form
+        pub fn to_bytes_uncompressed_form(&self) -> [u8; $uncompressed] {
+            let mut o = [0u8; $uncompressed];
+            self.0.serialize(&mut o[..].as_mut(), false).unwrap();
+            o
+        }
+    };
+}
+
+macro_rules! hash_elem_impl {
+    ($name:ident, $func:expr) => {
+        impl HashElem for $name {
+            type Output = $name;
+
+            fn hash<I: AsRef<[u8]>>(data: I) -> Self::Output {
+                $func(data.as_ref())
+            }
+        }
+    };
+}
+
+macro_rules! random_elem_impl {
+    ($name:ident, $func:block) => {
+        impl RandomElem for $name {
+            type Output = $name;
+
+            fn random() -> Self::Output $func
+        }
+    };
+}
+
+macro_rules! as_ref_impl {
+    ($name:ident, $inner:ident) => {
+        impl AsRef<$inner> for $name {
+            fn as_ref(&self) -> &$inner {
+                &self.0
+            }
+        }
+    };
+}
+

--- a/libzmix/bbs/src/messages.rs
+++ b/libzmix/bbs/src/messages.rs
@@ -16,7 +16,7 @@ macro_rules! sm_map {
 #[macro_export]
 macro_rules! pm_revealed {
     ($data:expr) => {
-        ProofMessage::Revealed(crate::SignatureMessage::hash($data))
+        ProofMessage::Revealed(SignatureMessage::hash($data))
     };
 }
 
@@ -35,12 +35,12 @@ macro_rules! pm_revealed_raw {
 macro_rules! pm_hidden {
     ($data:expr) => {
         ProofMessage::Hidden(HiddenMessage::ProofSpecificBlinding(
-            crate::SignatureMessage::hash($data),
+            SignatureMessage::hash($data),
         ))
     };
     ($data:expr, $bf:expr) => {
         ProofMessage::Hidden(HiddenMessage::ExternalBlinding(
-            crate::SignatureMessage::hash($data),
+            SignatureMessage::hash($data),
             $bf,
         ))
     };

--- a/libzmix/bbs/src/messages.rs
+++ b/libzmix/bbs/src/messages.rs
@@ -5,7 +5,7 @@ macro_rules! sm_map {
         {
             let mut msgs = std::collections::BTreeMap::new();
             $(
-                msgs.insert($index, SignatureMessage::from_msg_hash($data));
+                msgs.insert($index, crate::SignatureMessage::hash($data));
             )*
             msgs
         }
@@ -16,7 +16,7 @@ macro_rules! sm_map {
 #[macro_export]
 macro_rules! pm_revealed {
     ($data:expr) => {
-        ProofMessage::Revealed(SignatureMessage::from_msg_hash($data))
+        ProofMessage::Revealed(crate::SignatureMessage::hash($data))
     };
 }
 
@@ -35,12 +35,12 @@ macro_rules! pm_revealed_raw {
 macro_rules! pm_hidden {
     ($data:expr) => {
         ProofMessage::Hidden(HiddenMessage::ProofSpecificBlinding(
-            SignatureMessage::from_msg_hash($data),
+            crate::SignatureMessage::hash($data),
         ))
     };
     ($data:expr, $bf:expr) => {
         ProofMessage::Hidden(HiddenMessage::ExternalBlinding(
-            SignatureMessage::from_msg_hash($data),
+            crate::SignatureMessage::hash($data),
             $bf,
         ))
     };
@@ -57,7 +57,7 @@ macro_rules! pm_hidden_raw {
     };
 }
 
-use crate::types::*;
+use crate::{ProofNonce, SignatureMessage};
 
 /// A message classification by the prover
 pub enum ProofMessage {
@@ -86,5 +86,5 @@ pub enum HiddenMessage {
     /// Indicates the message is hidden but it is involved with other proofs
     ///     like boundchecks, set memberships or inequalities, so the blinding factor
     ///     is provided from an external source.
-    ExternalBlinding(SignatureMessage, SignatureNonce),
+    ExternalBlinding(SignatureMessage, ProofNonce),
 }

--- a/libzmix/bbs/src/pok_vc.rs
+++ b/libzmix/bbs/src/pok_vc.rs
@@ -10,18 +10,20 @@
 //! During response generation `ProverCommitted` is consumed to create `Proof` object containing the commitments and responses.
 //! `Proof` can then be verified by the verifier.
 
-use crate::prelude::*;
+use crate::{hash_to_fr, multi_scalar_mul_const_time_g1, ProofChallenge, SignatureMessage, GeneratorG1, ToVariableLengthBytes, FR_COMPRESSED_SIZE, G1_COMPRESSED_SIZE, G1_UNCOMPRESSED_SIZE, Commitment};
 
-use amcl_wrapper::constants::{
-    CURVE_ORDER_ELEMENT_SIZE, FIELD_ORDER_ELEMENT_SIZE, GROUP_G1_SIZE, GROUP_G2_SIZE,
-};
-use amcl_wrapper::curve_order_elem::CurveOrderElement;
-use amcl_wrapper::group_elem::{GroupElement, GroupElementVector};
-use amcl_wrapper::group_elem_g1::{G1Vector, G1};
-use amcl_wrapper::group_elem_g2::{G2Vector, G2};
 use failure::{Backtrace, Context, Fail};
-use serde::{Deserialize, Serialize};
-use std::fmt;
+use ff_zeroize::Field;
+use pairing_plus::{
+    bls12_381::{Fr, G1},
+    serdes::SerDes,
+    CurveAffine, CurveProjective,
+};
+use rand::prelude::*;
+use serde::{Deserialize, Serialize, Deserializer, Serializer, de::{Error as DError, Visitor}};
+use std::fmt::{self, Formatter};
+use std::io::{Cursor, Read};
+use std::convert::TryFrom;
 
 /// Convenience importing module
 pub mod prelude {
@@ -96,427 +98,346 @@ impl Fail for PoKVCError {
 }
 
 impl fmt::Display for PoKVCError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
         fmt::Display::fmt(&self.inner, f)
     }
 }
 
-/// Macro that creates all the classes used for Signature proofs of knowledge
-/// We do this as a macro because we may want abstract this for other signatures
-#[macro_export]
-macro_rules! impl_PoK_VC {
-    ( $ProverCommitting:ident, $ProverCommitted:ident, $Proof:ident, $group_element:ident, $group_element_vec:ident, $group_element_size:expr, $group_element_compressed_size:expr ) => {
-        /// Proof of knowledge of messages in a vector commitment.
-        /// Commit for each message or blinding factor used
-        #[derive(Clone, Debug, Serialize, Deserialize)]
-        pub struct $ProverCommitting {
-            /// The generators to use as the bases
-            pub gens: $group_element_vec,
-            blindings: SignatureMessageVector,
-        }
-
-        /// Receive or generate challenge. Compute response and proof
-        #[derive(Clone, Debug, Serialize, Deserialize)]
-        pub struct $ProverCommitted {
-            /// The generators to use as the bases
-            pub gens: $group_element_vec,
-            blindings: SignatureMessageVector,
-            /// The commitment to be verified as part of the proof
-            pub commitment: $group_element,
-        }
-
-        /// A proof of knowledge of a signature and hidden messages
-        #[derive(Clone, Debug, Serialize, Deserialize)]
-        pub struct $Proof {
-            /// The proof commitment of all base_0*exp_0+base_1*exp_1
-            pub commitment: $group_element,
-            /// s values in the fiat shamir protocol
-            pub responses: SignatureMessageVector,
-        }
-
-        impl $ProverCommitting {
-            /// Create a new prover committing struct
-            pub fn new() -> Self {
-                Self {
-                    gens: $group_element_vec::new(0),
-                    blindings: SignatureMessageVector::new(0),
-                }
-            }
-
-            /// Commit a base point with a blinding factor.
-            /// The blinding factor is generated randomly if none is supplied
-            /// generate a new random blinding if None provided
-            pub fn commit(
-                &mut self,
-                gen: &$group_element,
-                blinding: Option<&CurveOrderElement>,
-            ) -> usize {
-                let blinding = match blinding {
-                    Some(b) => b.clone(),
-                    None => CurveOrderElement::random(),
-                };
-                let idx = self.gens.len();
-                self.gens.push(gen.clone());
-                self.blindings.push(blinding);
-                idx
-            }
-
-            /// Add pairwise product of (`self.gens`, self.blindings). Uses multi-exponentiation.
-            pub fn finish(self) -> $ProverCommitted {
-                let commitment = self
-                    .gens
-                    .multi_scalar_mul_const_time(self.blindings.as_slice())
-                    .unwrap();
-                $ProverCommitted {
-                    gens: self.gens,
-                    blindings: self.blindings,
-                    commitment,
-                }
-            }
-
-            /// Return the generator and blinding factor at `idx`
-            pub fn get_index(
-                &self,
-                idx: usize,
-            ) -> Result<(&$group_element, &CurveOrderElement), PoKVCError> {
-                if idx >= self.gens.len() {
-                    return Err(PoKVCErrorKind::GeneralError {
-                        msg: format!("index {} greater than size {}", idx, self.gens.len()),
-                    }
-                    .into());
-                }
-                Ok((&self.gens[idx], &self.blindings[idx]))
-            }
-        }
-
-        impl Default for $ProverCommitting {
-            fn default() -> Self {
-                Self::new()
-            }
-        }
-
-        impl $ProverCommitted {
-            /// Convert the committed values to a byte array. Use for generating the fiat-shamir challenge
-            pub fn to_bytes(&self) -> Vec<u8> {
-                let mut bytes = vec![];
-                for b in self.gens.as_slice() {
-                    bytes.append(&mut b.to_vec());
-                }
-                bytes.append(&mut self.commitment.to_vec());
-                bytes
-            }
-
-            /// This step will be done by the main protocol for which this PoK is a sub-protocol
-            pub fn gen_challenge(&self, mut extra: Vec<u8>) -> CurveOrderElement {
-                let mut bytes = self.to_bytes();
-                bytes.append(&mut extra);
-                CurveOrderElement::from_msg_hash(&bytes)
-            }
-
-            /// For each secret, generate a response as self.blinding[i] - challenge*secrets[i].
-            pub fn gen_proof(
-                self,
-                challenge: &CurveOrderElement,
-                secrets: &[CurveOrderElement],
-            ) -> Result<$Proof, PoKVCError> {
-                if secrets.len() != self.gens.len() {
-                    return Err(PoKVCErrorKind::UnequalNoOfBasesExponents {
-                        bases: self.gens.len(),
-                        exponents: secrets.len(),
-                    }
-                    .into());
-                }
-                let mut responses = SignatureMessageVector::with_capacity(self.gens.len());
-                for i in 0..self.gens.len() {
-                    responses.push(&self.blindings[i] - (challenge * &secrets[i]));
-                }
-                Ok($Proof {
-                    commitment: self.commitment,
-                    responses,
-                })
-            }
-        }
-
-        impl $Proof {
-            /// Computes the piece that goes into verifying the overall proof component
-            /// by computing the c == H(U || \widehat{U} || nonce)
-            /// This returns the \widehat{U}
-            /// commitment is U
-            pub fn get_challenge_contribution(
-                &self,
-                bases: &[$group_element],
-                commitment: &$group_element,
-                challenge: &CurveOrderElement,
-            ) -> Result<$group_element, PoKVCError> {
-                // bases[0]^responses[0] * bases[0]^responses[0] * ... bases[i]^responses[i] * commitment^challenge == random_commitment
-                // =>
-                // bases[0]^responses[0] * bases[0]^responses[0] * ... bases[i]^responses[i] * commitment^challenge * random_commitment^-1 == 1
-                if bases.len() != self.responses.len() {
-                    return Err(PoKVCErrorKind::UnequalNoOfBasesExponents {
-                        bases: bases.len(),
-                        exponents: self.responses.len(),
-                    }
-                    .into());
-                }
-                let mut points = $group_element_vec::from(bases);
-                let mut scalars = self.responses.clone();
-                points.push(commitment.clone());
-                scalars.push(challenge.clone());
-                let pr = points
-                    .multi_scalar_mul_var_time(scalars.as_slice())
-                    .unwrap();
-                Ok(pr)
-            }
-
-            /// Verify that bases[0]^responses[0] * bases[0]^responses[0] * ... bases[i]^responses[i] * commitment^challenge == random_commitment
-            pub fn verify(
-                &self,
-                bases: &[$group_element],
-                commitment: &$group_element,
-                challenge: &CurveOrderElement,
-            ) -> Result<bool, PoKVCError> {
-                let pr = self.get_challenge_contribution(bases, commitment, challenge)?
-                    - &self.commitment;
-                Ok(pr.is_identity())
-            }
-
-            /// Assumes this is the entire proof and is not a sub proof
-            /// Used primarily during 2-PC signature creation
-            pub fn verify_complete_proof(
-                &self,
-                bases: &[$group_element],
-                commitment: &$group_element,
-                challenge: &CurveOrderElement,
-                nonce: &[u8],
-            ) -> Result<bool, PoKVCError> {
-                if bases.len() != self.responses.len() {
-                    return Err(PoKVCErrorKind::UnequalNoOfBasesExponents {
-                        bases: bases.len(),
-                        exponents: self.responses.len(),
-                    }
-                    .into());
-                }
-                let mut points = $group_element_vec::from(bases);
-                let mut scalars = self.responses.clone();
-                points.push(commitment.clone());
-                scalars.push(challenge.clone());
-                let pr = points
-                    .multi_scalar_mul_var_time(scalars.as_slice())
-                    .unwrap();
-                let mut pr_bytes = Vec::new();
-                for b in bases.iter() {
-                    pr_bytes.append(&mut b.to_vec())
-                }
-                pr_bytes.append(&mut pr.to_vec());
-                pr_bytes.extend_from_slice(commitment.to_vec().as_slice());
-                pr_bytes.extend_from_slice(nonce);
-                let hash = CurveOrderElement::from_msg_hash(pr_bytes.as_slice()) - challenge;
-                let pr = pr - &self.commitment;
-                Ok(pr.is_identity() && hash.is_zero())
-            }
-
-            /// Convert to raw bytes
-            pub fn to_bytes(&self) -> Vec<u8> {
-                let mut result = self.commitment.to_vec();
-                let len: u32 = self.responses.len() as u32;
-                result.extend_from_slice(&len.to_be_bytes()[..]);
-                for r in self.responses.iter() {
-                    result.extend_from_slice(&r.to_bytes()[..]);
-                }
-                result
-            }
-
-            /// Convert from raw bytes
-            pub fn from_bytes(data: &[u8]) -> Result<Self, PoKVCError> {
-                if data.len() < $group_element_size + 4 {
-                    return Err(PoKVCErrorKind::GeneralError {
-                        msg: format!("Invalid length"),
-                    }
-                    .into());
-                }
-                let commitment =
-                    $group_element::from_slice(&data[..$group_element_size]).map_err(|_| {
-                        PoKVCErrorKind::GeneralError {
-                            msg: format!("Invalid Length"),
-                        }
-                    })?;
-
-                let mut offset = $group_element_size;
-
-                let length = u32::from_be_bytes(*array_ref![data, offset, 4]) as usize;
-                offset += 4;
-
-                if data.len() < offset + length * FIELD_ORDER_ELEMENT_SIZE {
-                    return Err(PoKVCErrorKind::GeneralError {
-                        msg: format!("Invalid length"),
-                    }
-                    .into());
-                }
-
-                let mut responses = SignatureMessageVector::with_capacity(length);
-
-                for _ in 0..length {
-                    let end = offset + FIELD_ORDER_ELEMENT_SIZE;
-                    let r =
-                        CurveOrderElement::from(array_ref![data, offset, FIELD_ORDER_ELEMENT_SIZE]);
-                    responses.push(r);
-                    offset = end;
-                }
-                Ok(Self {
-                    commitment,
-                    responses,
-                })
-            }
-
-            /// Convert to raw bytes using the compressed form.
-            pub fn to_bytes_compressed_form(&self) -> Vec<u8> {
-                let responses_len = self.responses.len() as u32;
-                let mut output = Vec::with_capacity(
-                    $group_element_compressed_size
-                        + self.responses.len() * CURVE_ORDER_ELEMENT_SIZE
-                        + 4,
-                );
-
-                output.extend_from_slice(&self.commitment.to_compressed_bytes()[..]);
-                output.extend_from_slice(&responses_len.to_be_bytes()[..]);
-                for r in self.responses.iter() {
-                    output.extend_from_slice(&r.to_compressed_bytes()[..]);
-                }
-                output
-            }
-
-            /// Convert from compressed form raw bytes.
-            pub fn from_bytes_compressed_form(data: &[u8]) -> Result<Self, PoKVCError> {
-                if data.len() < $group_element_compressed_size + 4 {
-                    return Err(PoKVCErrorKind::GeneralError {
-                        msg: format!("Invalid length"),
-                    }
-                    .into());
-                }
-
-                let commitment =
-                    $group_element::from(array_ref![data, 0, $group_element_compressed_size]);
-                let responses_len =
-                    u32::from_be_bytes(*array_ref![data, $group_element_compressed_size, 4])
-                        as usize;
-
-                let mut offset = $group_element_compressed_size + 4;
-                let mut responses_vec = Vec::with_capacity(responses_len);
-                for _ in 0..responses_len {
-                    let response =
-                        SignatureMessage::from(array_ref![data, offset, CURVE_ORDER_ELEMENT_SIZE]);
-                    responses_vec.push(response);
-                    offset += CURVE_ORDER_ELEMENT_SIZE;
-                }
-                let responses = responses_vec.into();
-                Ok(Self {
-                    commitment,
-                    responses,
-                })
-            }
-        }
-
-        impl CompressedForm for $Proof {
-            type Output = $Proof;
-            type Error = PoKVCError;
-
-            /// Convert to raw bytes using compressed form.
-            fn to_bytes_compressed_form(&self) -> Vec<u8> {
-                let responses_len = self.responses.len() as u32;
-                let mut output = Vec::with_capacity(
-                    $group_element_compressed_size
-                        + self.responses.len() * CURVE_ORDER_ELEMENT_SIZE
-                        + 4,
-                );
-
-                output.extend_from_slice(&self.commitment.to_compressed_bytes()[..]);
-                output.extend_from_slice(&responses_len.to_be_bytes()[..]);
-                for r in self.responses.iter() {
-                    output.extend_from_slice(&r.to_compressed_bytes()[..]);
-                }
-                output
-            }
-
-            /// Convert from compressed form raw bytes.
-            fn from_bytes_compressed_form<I: AsRef<[u8]>>(data: I) -> Result<Self, PoKVCError> {
-                let data = data.as_ref();
-                if data.len() < $group_element_compressed_size + 4 {
-                    return Err(PoKVCErrorKind::GeneralError {
-                        msg: format!("Invalid length"),
-                    }
-                    .into());
-                }
-
-                let commitment =
-                    $group_element::from(array_ref![data, 0, $group_element_compressed_size]);
-                let responses_len =
-                    u32::from_be_bytes(*array_ref![data, $group_element_compressed_size, 4])
-                        as usize;
-
-                let mut offset = $group_element_compressed_size + 4;
-                let mut responses_vec = Vec::with_capacity(responses_len);
-                for _ in 0..responses_len {
-                    let response =
-                        SignatureMessage::from(array_ref![data, offset, CURVE_ORDER_ELEMENT_SIZE]);
-                    responses_vec.push(response);
-                    offset += CURVE_ORDER_ELEMENT_SIZE;
-                }
-                let responses = responses_vec.into();
-                Ok(Self {
-                    commitment,
-                    responses,
-                })
-            }
-        }
-    };
+/// Proof of knowledge of messages in a vector commitment.
+/// Commit for each message or blinding factor used
+#[derive(Clone, Debug)]
+pub struct ProverCommittingG1 {
+    bases: Vec<G1>,
+    blinding_factors: Vec<Fr>,
 }
+
+/// Receive or generate challenge. Compute response and proof
+#[derive(Clone, Debug)]
+pub struct ProverCommittedG1 {
+    /// The generators to use as the bases
+    bases: Vec<G1>,
+    /// The blinding factors as part of the proof
+    blinding_factors: Vec<Fr>,
+    /// The commitment to be verified as part of the proof
+    commitment: G1,
+}
+
+/// A proof of knowledge of a signature and hidden messages
+#[derive(Clone, Debug)]
+pub struct ProofG1 {
+    /// The proof commitment of all base_0*exp_0+base_1*exp_1
+    pub(crate) commitment: G1,
+    /// s values in the fiat shamir protocol
+    pub(crate) responses: Vec<Fr>,
+}
+
+impl ProverCommittingG1 {
+    /// Create a new prover committing struct
+    pub fn new() -> Self {
+        Self {
+            bases: Vec::new(),
+            blinding_factors: Vec::new(),
+        }
+    }
+
+    /// Commit a base point with a blinding factor.
+    /// The blinding factor is generated randomly
+    pub fn commit<B: AsRef<G1>>(&mut self, base: B) -> usize {
+        let mut rng = thread_rng();
+        let idx = self.bases.len();
+        self.bases.push(base.as_ref().clone());
+        self.blinding_factors.push( Fr::random(&mut rng));
+        idx
+    }
+
+    /// Commit a base point with a blinding factor.
+    pub fn commit_with<B: AsRef<G1>, S: AsRef<Fr>>(&mut self, base: B, blinding_factor: S) -> usize {
+        let idx = self.bases.len();
+        self.bases.push(base.as_ref().clone());
+        self.blinding_factors.push(blinding_factor.as_ref().clone());
+        idx
+    }
+
+    /// Add pairwise product of (`self.bases`, self.blindings). Uses multi-exponentiation.
+    pub fn finish(self) -> ProverCommittedG1 {
+        let commitment = multi_scalar_mul_const_time_g1(&self.bases, &self.blinding_factors);
+        ProverCommittedG1 {
+            bases: self.bases,
+            blinding_factors: self.blinding_factors,
+            commitment,
+        }
+    }
+
+    /// Return the generator and blinding factor at `idx`
+    pub fn get_index(&self, idx: usize) -> Result<(GeneratorG1, SignatureMessage), PoKVCError> {
+        if idx >= self.bases.len() {
+            return Err(PoKVCErrorKind::GeneralError {
+                msg: format!("index {} greater than size {}", idx, self.bases.len()),
+            }
+            .into());
+        }
+        Ok((GeneratorG1(self.bases[idx].clone()), SignatureMessage(self.blinding_factors[idx].clone())))
+    }
+}
+
+impl Default for ProverCommittingG1 {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ProverCommittedG1 {
+    /// Convert the committed values to a byte array. Use for generating the fiat-shamir challenge
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        for b in &self.bases {
+            b.serialize(&mut bytes, false).unwrap();
+        }
+        self.commitment.serialize(&mut bytes, false).unwrap();
+        bytes
+    }
+
+    /// This step will be done by the main protocol for which this PoK is a sub-protocol
+    pub fn gen_challenge<I: AsRef<[u8]>>(&self, extra: I) -> ProofChallenge {
+        let mut bytes = self.to_bytes();
+        bytes.extend_from_slice(extra.as_ref());
+        ProofChallenge(hash_to_fr(&bytes))
+    }
+
+    /// For each secret, generate a response as self.blinding[i] - challenge*secrets[i].
+    pub fn gen_proof(
+        self,
+        challenge: &ProofChallenge,
+        secrets: &[SignatureMessage],
+    ) -> Result<ProofG1, PoKVCError> {
+        if secrets.len() != self.bases.len() {
+            return Err(PoKVCErrorKind::UnequalNoOfBasesExponents {
+                bases: self.bases.len(),
+                exponents: secrets.len(),
+            }
+            .into());
+        }
+        let mut responses = Vec::with_capacity(self.bases.len());
+        for i in 0..self.bases.len() {
+            let mut c = challenge.0.clone();
+            c.mul_assign(&secrets[i].0);
+            let mut s = self.blinding_factors[i].clone();
+            s.sub_assign(&c);
+            responses.push(s);
+        }
+        Ok(ProofG1 {
+            commitment: self.commitment,
+            responses,
+        })
+    }
+}
+
+impl ProofG1 {
+    /// Computes the piece that goes into verifying the overall proof component
+    /// by computing the c == H(U || \widehat{U} || nonce)
+    /// This returns the \widehat{U}
+    /// commitment is U
+    pub fn get_challenge_contribution(
+        &self,
+        bases: &[GeneratorG1],
+        commitment: &Commitment,
+        challenge: &ProofChallenge,
+    ) -> Result<GeneratorG1, PoKVCError> {
+        // bases[0]^responses[0] * bases[0]^responses[0] * ... bases[i]^responses[i] * commitment^challenge == random_commitment
+        // =>
+        // bases[0]^responses[0] * bases[0]^responses[0] * ... bases[i]^responses[i] * commitment^challenge * random_commitment^-1 == 1
+        let bases = bases.as_ref();
+        if bases.len() != self.responses.len() {
+            return Err(PoKVCErrorKind::UnequalNoOfBasesExponents {
+                bases: bases.len(),
+                exponents: self.responses.len(),
+            }
+            .into());
+        }
+        let mut points: Vec<G1> = bases.iter().map(|g| g.0.clone()).collect();
+        let mut scalars = self.responses.clone();
+        points.push(commitment.0.clone());
+        scalars.push(challenge.0.clone());
+        Ok(GeneratorG1(multi_scalar_mul_const_time_g1(&points, &scalars)))
+    }
+
+    /// Verify that bases[0]^responses[0] * bases[0]^responses[0] * ... bases[i]^responses[i] * commitment^challenge == random_commitment
+    pub fn verify(
+        &self,
+        bases: &[GeneratorG1],
+        commitment: &Commitment,
+        challenge: &ProofChallenge,
+    ) -> Result<bool, PoKVCError> {
+        let mut pr = self.get_challenge_contribution(bases, commitment, challenge)?;
+        pr.0.sub_assign(&self.commitment);
+        Ok(pr.0.is_zero())
+    }
+
+    /// Assumes this is the entire proof and is not a sub proof
+    /// Used primarily during 2-PC signature creation
+    pub fn verify_complete_proof(
+        &self,
+        bases: &[GeneratorG1],
+        commitment: &Commitment,
+        challenge: &ProofChallenge,
+        nonce: &[u8],
+    ) -> Result<bool, PoKVCError> {
+        let bases = bases.as_ref();
+        if bases.len() != self.responses.len() {
+            return Err(PoKVCErrorKind::UnequalNoOfBasesExponents {
+                bases: bases.len(),
+                exponents: self.responses.len(),
+            }
+            .into());
+        }
+        let mut points: Vec<G1> = bases.iter().map(|b| b.0.clone()).collect();
+        let bases = points.clone();
+        let mut scalars = self.responses.clone();
+        points.push(commitment.0.clone());
+        scalars.push(challenge.0.clone());
+        let mut pr = multi_scalar_mul_const_time_g1(&points, &scalars);
+        let mut pr_bytes = Vec::new();
+
+        for b in bases {
+            pr_bytes.extend_from_slice(b.into_affine().into_uncompressed().as_ref());
+        }
+        pr_bytes.extend_from_slice(pr.into_affine().into_uncompressed().as_ref());
+        pr_bytes.extend_from_slice(commitment.0.into_affine().into_uncompressed().as_ref());
+        pr_bytes.extend_from_slice(nonce);
+        let mut hash = hash_to_fr(pr_bytes.as_slice());
+        hash.sub_assign(&challenge.0);
+        pr.sub_assign(&self.commitment);
+        Ok(pr.is_zero() && hash.is_zero())
+    }
+
+    /// Convert to raw bytes
+    pub(crate) fn to_bytes(&self, compressed: bool) -> Vec<u8> {
+        let mut result = Vec::new();
+        self.commitment.serialize(&mut result, compressed).unwrap();
+        let len: u32 = self.responses.len() as u32;
+        result.extend_from_slice(&len.to_be_bytes()[..]);
+
+        for r in self.responses.iter() {
+            r.serialize(&mut result, compressed).unwrap();
+        }
+        result
+    }
+
+    /// Convert from raw bytes
+    pub(crate) fn from_bytes(
+        data: &[u8],
+        g_size: usize,
+        compressed: bool,
+    ) -> Result<Self, PoKVCError> {
+        if data.len() < g_size + 4 {
+            return Err(PoKVCErrorKind::GeneralError {
+                msg: format!("Invalid length"),
+            }
+            .into());
+        }
+        let mut c = Cursor::new(data);
+
+        let commitment =
+            slice_to_elem!(&mut c, G1, compressed).map_err(|_| PoKVCErrorKind::GeneralError {
+                msg: format!("Invalid Length"),
+            })?;
+
+        let mut length_bytes = [0u8; 4];
+        c.read_exact(&mut length_bytes).unwrap();
+        let length = u32::from_be_bytes(length_bytes) as usize;
+
+        if data.len() < g_size + 4 + length * FR_COMPRESSED_SIZE {
+            return Err(PoKVCErrorKind::GeneralError {
+                msg: format!("Invalid length"),
+            }
+            .into());
+        }
+
+        let mut responses = Vec::with_capacity(length);
+
+        for _ in 0..length {
+            let r = slice_to_elem!(&mut c, Fr, compressed).map_err(|_| {
+                PoKVCErrorKind::GeneralError {
+                    msg: format!("Invalid length"),
+                }
+            })?;
+            responses.push(r);
+        }
+        Ok(Self {
+            commitment,
+            responses,
+        })
+    }
+}
+
+impl ToVariableLengthBytes for ProofG1 {
+    type Output = ProofG1;
+    type Error = PoKVCError;
+
+    fn to_bytes_compressed_form(&self) -> Vec<u8> {
+        self.to_bytes(true)
+    }
+
+    fn from_bytes_compressed_form<I: AsRef<[u8]>>(data: I) -> Result<Self, PoKVCError> {
+        Self::from_bytes(data.as_ref(), G1_COMPRESSED_SIZE, true)
+    }
+
+    fn to_bytes_uncompressed_form(&self) -> Vec<u8> {
+        self.to_bytes(false)
+    }
+
+    fn from_bytes_uncompressed_form<I: AsRef<[u8]>>(data: I) -> Result<Self, PoKVCError> {
+        Self::from_bytes(data.as_ref(), G1_UNCOMPRESSED_SIZE, false)
+    }
+}
+
+try_from_impl!(ProofG1, PoKVCError);
+serdes_impl!(ProofG1);
 
 #[cfg(test)]
 macro_rules! test_PoK_VC {
-    ( $n:ident, $ProverCommitting:ident, $ProverCommitted:ident, $Proof:ident, $group_element:ident, $group_element_vec:ident ) => {
-        let mut gens = $group_element_vec::with_capacity($n);
-        let mut secrets = SignatureMessageVector::with_capacity($n);
+    ( $n:ident, $ProverCommitting:ident, $ProverCommitted:ident, $Proof:ident, $group_element:ident, $group_element_size:ident ) => {
+        let mut gens = Vec::with_capacity($n);
+        let mut secrets = Vec::with_capacity($n);
         let mut commiting = $ProverCommitting::new();
         for _ in 0..$n - 1 {
             let g = $group_element::random();
-            commiting.commit(&g, None);
+            commiting.commit(&g);
             gens.push(g);
-            secrets.push(CurveOrderElement::random());
+            secrets.push(SignatureMessage::random());
         }
 
         // Add one of the blindings externally
         let g = $group_element::random();
-        let r = CurveOrderElement::random();
-        commiting.commit(&g, Some(&r));
+        let r = SignatureMessage::random();
+        commiting.commit_with(&g, &r);
         let (g_, r_) = commiting.get_index($n - 1).unwrap();
-        assert_eq!(g, *g_);
-        assert_eq!(r, *r_);
+        assert_eq!(g, g_);
+        assert_eq!(r, r_);
         gens.push(g);
-        secrets.push(CurveOrderElement::random());
+        secrets.push(SignatureMessage::random());
 
         // Bound check for get_index
         assert!(commiting.get_index($n).is_err());
         assert!(commiting.get_index($n + 1).is_err());
 
         let committed = commiting.finish();
-        let commitment = gens
-            .multi_scalar_mul_const_time(secrets.as_slice())
-            .unwrap();
+        let gs: Vec<G1> = gens.iter().map(|g| g.0).collect();
+        let ss: Vec<Fr> = secrets.iter().map(|s| s.0).collect();
+        let commitment = Commitment(multi_scalar_mul_const_time_g1(&gs, &ss));
         let challenge = committed.gen_challenge(committed.to_bytes());
         let proof = committed.gen_proof(&challenge, secrets.as_slice()).unwrap();
 
         assert!(proof
-            .verify(gens.as_slice(), &commitment, &challenge)
+            .verify(&gens, &commitment, &challenge)
             .unwrap());
 
-        let proof_bytes = proof.to_bytes();
+        let proof_bytes = proof.to_bytes_uncompressed_form();
         assert_eq!(
             proof_bytes.len(),
-            $group_element::random().to_vec().len()
-                + 4
-                + FIELD_ORDER_ELEMENT_SIZE * proof.responses.len()
+            $group_element_size + 4 + FR_COMPRESSED_SIZE * proof.responses.len()
         );
-        let res_proof_cp = $Proof::from_bytes(&proof_bytes);
+        let res_proof_cp = $Proof::from_bytes_uncompressed_form(&proof_bytes);
         assert!(res_proof_cp.is_ok());
 
         // Unequal number of generators and responses
@@ -537,44 +458,33 @@ macro_rules! test_PoK_VC {
 
         // Wrong commitment fails to verify
         assert!(!proof
-            .verify(gens.as_slice(), &$group_element::random(), &challenge)
+            .verify(
+                gens.as_slice(),
+                &Commitment(GeneratorG1::random().0),
+                &challenge
+            )
             .unwrap());
         // Wrong challenge fails to verify
         assert!(!proof
-            .verify(gens.as_slice(), &commitment, &CurveOrderElement::random())
+            .verify(gens.as_slice(), &commitment, &ProofChallenge::random())
             .unwrap());
     };
 }
 
 // Proof of knowledge of committed values in a vector commitment. The commitment lies in group G1.
-impl_PoK_VC!(
-    ProverCommittingG1,
-    ProverCommittedG1,
-    ProofG1,
-    G1,
-    G1Vector,
-    GROUP_G1_SIZE,
-    FIELD_ORDER_ELEMENT_SIZE
-);
-
-// Proof of knowledge of committed values in a vector commitment. The commitment lies in group G2.
-impl_PoK_VC!(
-    ProverCommittingG2,
-    ProverCommittedG2,
-    ProofG2,
-    G2,
-    G2Vector,
-    GROUP_G2_SIZE,
-    2 * FIELD_ORDER_ELEMENT_SIZE
-);
+// pok_vc_impl!(
+//     ProverCommittingG1,
+//     ProverCommittedG1,
+//     ProofG1,
+//     G1,
+//     G1_UNCOMPRESSED_SIZE,
+//     G1_COMPRESSED_SIZE
+// );
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use amcl_wrapper::curve_order_elem::CurveOrderElement;
-    use amcl_wrapper::group_elem::{GroupElement, GroupElementVector};
-    use amcl_wrapper::group_elem_g1::{G1Vector, G1};
-    use amcl_wrapper::group_elem_g2::{G2Vector, G2};
+    use crate::RandomElem;
 
     #[test]
     fn test_pok_vc_g1() {
@@ -584,21 +494,21 @@ mod tests {
             ProverCommittingG1,
             ProverCommittedG1,
             ProofG1,
-            G1,
-            G1Vector
+            GeneratorG1,
+            G1_UNCOMPRESSED_SIZE
         );
     }
 
-    #[test]
-    fn test_pok_vc_g2() {
-        let n = 5;
-        test_PoK_VC!(
-            n,
-            ProverCommittingG2,
-            ProverCommittedG2,
-            ProofG2,
-            G2,
-            G2Vector
-        );
-    }
+    // #[test]
+    // fn test_pok_vc_g2() {
+    //     let n = 5;
+    //     test_PoK_VC!(
+    //         n,
+    //         ProverCommittingG2,
+    //         ProverCommittedG2,
+    //         ProofG2,
+    //         G2,
+    //         G2_UNCOMPRESSED_SIZE
+    //     );
+    // }
 }

--- a/libzmix/bbs/src/pok_vc.rs
+++ b/libzmix/bbs/src/pok_vc.rs
@@ -485,16 +485,6 @@ macro_rules! test_PoK_VC {
     };
 }
 
-// Proof of knowledge of committed values in a vector commitment. The commitment lies in group G1.
-// pok_vc_impl!(
-//     ProverCommittingG1,
-//     ProverCommittedG1,
-//     ProofG1,
-//     G1,
-//     G1_UNCOMPRESSED_SIZE,
-//     G1_COMPRESSED_SIZE
-// );
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -512,17 +502,4 @@ mod tests {
             G1_UNCOMPRESSED_SIZE
         );
     }
-
-    // #[test]
-    // fn test_pok_vc_g2() {
-    //     let n = 5;
-    //     test_PoK_VC!(
-    //         n,
-    //         ProverCommittingG2,
-    //         ProverCommittedG2,
-    //         ProofG2,
-    //         G2,
-    //         G2_UNCOMPRESSED_SIZE
-    //     );
-    // }
 }

--- a/libzmix/bbs/src/prover.rs
+++ b/libzmix/bbs/src/prover.rs
@@ -9,9 +9,8 @@ use crate::signature::prelude::*;
 /// The prover can either have the issuer sign all messages
 /// or can have some (0 to all) messages blindly signed by the issuer.
 use crate::{
-    BlindSignatureContext, CommitmentBuilder,
-    ProofChallenge, ProofNonce, ProofRequest, RandomElem, SignatureBlinding, SignatureMessage,
-    SignatureProof,
+    BlindSignatureContext, CommitmentBuilder, ProofChallenge, ProofNonce, ProofRequest, RandomElem,
+    SignatureBlinding, SignatureMessage, SignatureProof,
 };
 use std::collections::BTreeMap;
 

--- a/libzmix/bbs/src/prover.rs
+++ b/libzmix/bbs/src/prover.rs
@@ -10,7 +10,7 @@ use crate::signature::prelude::*;
 /// or can have some (0 to all) messages blindly signed by the issuer.
 use crate::{
     BlindSignatureContext, CommitmentBuilder, ProofChallenge, ProofNonce, ProofRequest, RandomElem,
-    SignatureBlinding, SignatureMessage, SignatureProof,
+    SignatureBlinding, SignatureMessage, SignatureProof, HashElem
 };
 use std::collections::BTreeMap;
 
@@ -125,19 +125,19 @@ impl Prover {
     pub fn create_challenge_hash(
         pok_sigs: Vec<PoKOfSignature>,
         claims: Vec<&str>,
-        nonce: &SignatureNonce,
-    ) -> Result<SignatureNonce, BBSError> {
+        nonce: &ProofNonce,
+    ) -> Result<ProofChallenge, BBSError> {
         let mut bytes = Vec::new();
 
         for p in pok_sigs {
             bytes.extend_from_slice(p.to_bytes().as_slice());
         }
-        bytes.extend_from_slice(&nonce.to_bytes()[..]);
+        bytes.extend_from_slice(&nonce.to_bytes_uncompressed_form()[..]);
         for c in claims {
             bytes.extend_from_slice(c.as_bytes());
         }
 
-        let challenge = SignatureNonce::from_msg_hash(&bytes);
+        let challenge = ProofChallenge::hash(&bytes);
 
         Ok(challenge)
     }

--- a/libzmix/bbs/src/prover.rs
+++ b/libzmix/bbs/src/prover.rs
@@ -9,8 +9,8 @@ use crate::signature::prelude::*;
 /// The prover can either have the issuer sign all messages
 /// or can have some (0 to all) messages blindly signed by the issuer.
 use crate::{
-    BlindSignatureContext, CommitmentBuilder, ProofChallenge, ProofNonce, ProofRequest, RandomElem,
-    SignatureBlinding, SignatureMessage, SignatureProof, HashElem
+    BlindSignatureContext, CommitmentBuilder, HashElem, ProofChallenge, ProofNonce, ProofRequest,
+    RandomElem, SignatureBlinding, SignatureMessage, SignatureProof,
 };
 use std::collections::BTreeMap;
 

--- a/libzmix/bbs/src/signature.rs
+++ b/libzmix/bbs/src/signature.rs
@@ -1,6 +1,10 @@
 use crate::errors::prelude::*;
 use crate::keys::prelude::*;
-use crate::{multi_scalar_mul_const_time_g1, Commitment, RandomElem, SignatureBlinding, SignatureMessage, FR_COMPRESSED_SIZE, G1_COMPRESSED_SIZE, G1_UNCOMPRESSED_SIZE, multi_scalar_mul_var_time_g1};
+use crate::{
+    multi_scalar_mul_const_time_g1, multi_scalar_mul_var_time_g1, Commitment, RandomElem,
+    SignatureBlinding, SignatureMessage, FR_COMPRESSED_SIZE, G1_COMPRESSED_SIZE,
+    G1_UNCOMPRESSED_SIZE,
+};
 use ff_zeroize::{Field, PrimeField};
 use pairing_plus::{
     bls12_381::{Bls12, Fq12, Fr, FrRepr, G1, G2},

--- a/libzmix/bbs/src/signature.rs
+++ b/libzmix/bbs/src/signature.rs
@@ -103,13 +103,13 @@ macro_rules! try_from_impl {
             }
         }
 
-         impl TryFrom<Vec<u8>> for $name {
+        impl TryFrom<Vec<u8>> for $name {
             type Error = BBSError;
 
             fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
                 Self::try_from(value.as_slice())
             }
-         }
+        }
     };
 }
 

--- a/libzmix/bbs/src/signature.rs
+++ b/libzmix/bbs/src/signature.rs
@@ -102,6 +102,14 @@ macro_rules! try_from_impl {
                 Ok(Self { a, e, s })
             }
         }
+
+         impl TryFrom<Vec<u8>> for $name {
+            type Error = BBSError;
+
+            fn try_from(value: Vec<u8>) -> Result<Self, Self::Error> {
+                Self::try_from(value.as_slice())
+            }
+         }
     };
 }
 

--- a/libzmix/bbs/src/signature.rs
+++ b/libzmix/bbs/src/signature.rs
@@ -226,7 +226,7 @@ impl Signature {
         verkey: &PublicKey,
     ) -> Result<Self, BBSError> {
         check_verkey_message!(
-            messages.len() != verkey.message_count(),
+            messages.len() > verkey.message_count(),
             verkey.message_count(),
             messages.len()
         );
@@ -308,7 +308,8 @@ impl Signature {
         bases.push(verkey.h0.0.clone());
         scalars.push((*s).clone());
 
-        for i in 0..verkey.message_count() {
+        let min = std::cmp::min(verkey.message_count(), messages.len());
+        for i in 0..min {
             bases.push(verkey.h[i].0.clone());
             scalars.push(messages[i].0.clone());
         }
@@ -384,7 +385,7 @@ mod tests {
         assert!(res.is_ok());
         let messages = Vec::new();
         let res = Signature::new(messages.as_slice(), &signkey, &verkey);
-        assert!(res.is_err());
+        assert!(res.is_ok());
     }
 
     #[test]

--- a/libzmix/bbs/src/verifier.rs
+++ b/libzmix/bbs/src/verifier.rs
@@ -1,6 +1,12 @@
+use crate::errors::prelude::*;
+use crate::keys::prelude::*;
+use crate::pok_sig::prelude::*;
 /// The verifier of a signature or credential asks for messages to be revealed from
 /// a prover and checks the signature proof of knowledge against a trusted issuer's public key.
-use crate::prelude::*;
+use crate::{
+    HashElem, ProofChallenge, ProofNonce, ProofRequest, RandomElem, SignatureMessage,
+    SignatureProof,
+};
 use std::collections::BTreeSet;
 
 /// This struct represents an Verifier of signatures.
@@ -38,15 +44,15 @@ impl Verifier {
     pub fn verify_signature_pok(
         proof_request: &ProofRequest,
         signature_proof: &SignatureProof,
-        nonce: &SignatureNonce,
+        nonce: &ProofNonce,
     ) -> Result<Vec<SignatureMessage>, BBSError> {
         let mut challenge_bytes = signature_proof.proof.get_bytes_for_challenge(
             proof_request.revealed_messages.clone(),
             &proof_request.verification_key,
         );
-        challenge_bytes.extend_from_slice(&nonce.to_bytes()[..]);
+        challenge_bytes.extend_from_slice(&nonce.to_bytes_uncompressed_form()[..]);
 
-        let challenge_verifier = SignatureNonce::from_msg_hash(&challenge_bytes);
+        let challenge_verifier = ProofChallenge::hash(&challenge_bytes);
         match signature_proof.proof.verify(
             &proof_request.verification_key,
             &signature_proof.revealed_messages,
@@ -62,7 +68,7 @@ impl Verifier {
     }
 
     /// Create a nonce used for the proof request context
-    pub fn generate_proof_nonce() -> SignatureNonce {
-        SignatureNonce::random()
+    pub fn generate_proof_nonce() -> ProofNonce {
+        ProofNonce::random()
     }
 }

--- a/libzmix/bbs/tests/bbs.rs
+++ b/libzmix/bbs/tests/bbs.rs
@@ -351,7 +351,7 @@ fn bbs_demo() {
     // (one of which is the blinded link secret)
     let (pk1, sk1) = Issuer::new_keys(5).unwrap();
 
-    let same_claim = SignatureMessage::from_msg_hash(b"same_claim");
+    let same_claim = SignatureMessage::hash(b"same_claim");
 
     // Prover desires a credential from Issuer1,
     // Issuer1 constructs the credential
@@ -470,11 +470,11 @@ fn bbs_demo() {
     // claim2 from credential1 and claim3 from credential2.
 
     // Prover creates a blinding factor to use for his link secrets.
-    let link_secret_blinding = SignatureNonce::random();
+    let link_secret_blinding = ProofNonce::random();
 
     // Prover creates a blinding factor to use for the ZK equality proof of
     // claim2 from credential1 and claim3 from credential2.
-    let same_blinding = SignatureNonce::random();
+    let same_blinding = ProofNonce::random();
 
     // Prover constructs proof messages from credential1
     // for selective disclosure of claim1 and ZK equality proof of claim2
@@ -512,8 +512,8 @@ fn bbs_demo() {
 
     // Prover completes challenge_bytes by adding verifier_nonce,
     // then constructs the challenge
-    chal_bytes.extend_from_slice(&verifier_nonce.to_bytes()[..]);
-    let challenge = SignatureNonce::from_msg_hash(&chal_bytes);
+    chal_bytes.extend_from_slice(&verifier_nonce.to_bytes_uncompressed_form()[..]);
+    let challenge = ProofChallenge::hash(&chal_bytes);
 
     // Prover constructs the proofs and sends them to the Verifier
     let proof1 = Prover::generate_signature_pok(pok1, &challenge).unwrap();
@@ -537,8 +537,8 @@ fn bbs_demo() {
 
     // Verifier completes ver_challenge_bytes by adding verifier_nonce,
     // then constructs the challenge
-    ver_chal_bytes.extend_from_slice(&verifier_nonce.to_bytes()[..]);
-    let ver_challenge = SignatureNonce::from_msg_hash(&ver_chal_bytes);
+    ver_chal_bytes.extend_from_slice(&verifier_nonce.to_bytes_uncompressed_form()[..]);
+    let ver_challenge = ProofChallenge::hash(&ver_chal_bytes);
 
     // Verifier checks proof1
     let res1 = proof1.proof.verify(

--- a/libzmix/bbs/tests/bbs.rs
+++ b/libzmix/bbs/tests/bbs.rs
@@ -206,7 +206,9 @@ fn pok_sig_extra_message() {
     };
 
     proof.revealed_messages.remove(&4);
-    proof.revealed_messages.insert(3, SignatureMessage::random());
+    proof
+        .revealed_messages
+        .insert(3, SignatureMessage::random());
     match Verifier::verify_signature_pok(&proof_request, &proof, &nonce) {
         Ok(_) => assert!(false),
         Err(_) => assert!(true),

--- a/libzmix/bbs/tests/bbs.rs
+++ b/libzmix/bbs/tests/bbs.rs
@@ -279,11 +279,11 @@ fn test_challenge_hash_with_prover_claims() {
     //issue credential
     let (pk, sk) = Issuer::new_keys(5).unwrap();
     let messages = vec![
-        SignatureMessage::from_msg_hash(b"message_1"),
-        SignatureMessage::from_msg_hash(b"message_2"),
-        SignatureMessage::from_msg_hash(b"message_3"),
-        SignatureMessage::from_msg_hash(b"message_4"),
-        SignatureMessage::from_msg_hash(b"message_5"),
+        SignatureMessage::hash(b"message_1"),
+        SignatureMessage::hash(b"message_2"),
+        SignatureMessage::hash(b"message_3"),
+        SignatureMessage::hash(b"message_4"),
+        SignatureMessage::hash(b"message_5"),
     ];
 
     let signature = Signature::new(messages.as_slice(), &sk, &pk).unwrap();
@@ -327,8 +327,8 @@ fn test_challenge_hash_with_prover_claims() {
 
     // Verifier completes ver_challenge_bytes by adding verifier_nonce,
     // then constructs the challenge
-    ver_chal_bytes.extend_from_slice(&nonce.to_bytes()[..]);
-    let ver_challenge = SignatureNonce::from_msg_hash(&ver_chal_bytes);
+    ver_chal_bytes.extend_from_slice(&nonce.to_bytes_uncompressed_form()[..]);
+    let ver_challenge = ProofChallenge::hash(&ver_chal_bytes);
 
     // Verifier checks proof1
     let res = proof.proof.verify(


### PR DESCRIPTION
Sorry, this looks like a BIG PR which it is, but the biggest change is switching from Apache Milagro which is no longer under development to [pairing-plus](https://crates.io/crates/pairing-plus).
Because of this change, it touched 90% of the BBS+ code. This PR only touches the BBS+ code. I have not applied it to the rest of ZMix yet.

Using pairing-plus offers the following advantages:

1- It's under active development
2- It's slightly faster overall about 5-10% faster than milagro in every case.
3- It's significantly faster for HashToCurve, about 100X faster.
4- Built-in compression methods rather than manually doing it.
5- ABI agnostic, it runs the same speed on 64-bit and 32-bit.
6- Unified function names i.e. `to_bytes_compressed_form` everywhere vs just in BBS