### PR TITLE
Error auto convert

### DIFF
--- a/libzmix/bbs/Cargo.toml
+++ b/libzmix/bbs/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 name = "bbs"
 readme = "README.md"
 repository = "https://github.com/hyperledger/ursa"
-version = "0.4.0"
+version = "0.4.1"
 
 [badges]
 maintenance = { status = "active" }

--- a/libzmix/bbs/src/errors.rs
+++ b/libzmix/bbs/src/errors.rs
@@ -99,7 +99,9 @@ impl From<BBSErrorKind> for BBSError {
 
 impl From<std::io::Error> for BBSError {
     fn from(err: std::io::Error) -> BBSError {
-        BBSError::from_kind(BBSErrorKind::GeneralError { msg: format!("{:?}", err)})
+        BBSError::from_kind(BBSErrorKind::GeneralError {
+            msg: format!("{:?}", err),
+        })
     }
 }
 

--- a/libzmix/bbs/src/errors.rs
+++ b/libzmix/bbs/src/errors.rs
@@ -97,6 +97,12 @@ impl From<BBSErrorKind> for BBSError {
     }
 }
 
+impl From<std::io::Error> for BBSError {
+    fn from(err: std::io::Error) -> BBSError {
+        BBSError::from_kind(BBSErrorKind::GeneralError { msg: format!("{:?}", err)})
+    }
+}
+
 impl std::fmt::Display for BBSError {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let mut first = true;

--- a/libzmix/bbs/src/keys.rs
+++ b/libzmix/bbs/src/keys.rs
@@ -112,12 +112,10 @@ impl PublicKey {
         }
         let mut c = Cursor::new(data.as_ref());
         let w = GeneratorG2(
-            G2::deserialize(&mut c, compressed)
-                .map_err(|_| BBSError::from_kind(BBSErrorKind::MalformedPublicKey))?,
+            G2::deserialize(&mut c, compressed)?,
         );
         let h0 = GeneratorG1(
-            G1::deserialize(&mut c, compressed)
-                .map_err(|_| BBSError::from_kind(BBSErrorKind::MalformedPublicKey))?,
+            G1::deserialize(&mut c, compressed)?,
         );
 
         let mut h_bytes = [0u8; 4];
@@ -127,8 +125,7 @@ impl PublicKey {
         let mut h = Vec::with_capacity(h_size);
         for _ in 0..h_size {
             let p = GeneratorG1(
-                G1::deserialize(&mut c, compressed)
-                    .map_err(|_| BBSError::from_kind(BBSErrorKind::MalformedPublicKey))?,
+                G1::deserialize(&mut c, compressed)?,
             );
             h.push(p);
         }
@@ -228,8 +225,7 @@ impl DeterministicPublicKey {
         let mc_bytes = (message_count as u32).to_be_bytes();
         let mut data = Vec::with_capacity(9 + G2_UNCOMPRESSED_SIZE);
         self.0
-            .serialize(&mut data, false)
-            .map_err(|_| BBSError::from_kind(BBSErrorKind::KeyGenError))?;
+            .serialize(&mut data, false)?;
         // Spacer
         data.push(0u8);
         let offset = data.len();

--- a/libzmix/bbs/src/keys.rs
+++ b/libzmix/bbs/src/keys.rs
@@ -111,12 +111,8 @@ impl PublicKey {
             return Err(BBSErrorKind::MalformedPublicKey.into());
         }
         let mut c = Cursor::new(data.as_ref());
-        let w = GeneratorG2(
-            G2::deserialize(&mut c, compressed)?,
-        );
-        let h0 = GeneratorG1(
-            G1::deserialize(&mut c, compressed)?,
-        );
+        let w = GeneratorG2(G2::deserialize(&mut c, compressed)?);
+        let h0 = GeneratorG1(G1::deserialize(&mut c, compressed)?);
 
         let mut h_bytes = [0u8; 4];
         c.read_exact(&mut h_bytes).unwrap();
@@ -124,9 +120,7 @@ impl PublicKey {
         let h_size = u32::from_be_bytes(h_bytes) as usize;
         let mut h = Vec::with_capacity(h_size);
         for _ in 0..h_size {
-            let p = GeneratorG1(
-                G1::deserialize(&mut c, compressed)?,
-            );
+            let p = GeneratorG1(G1::deserialize(&mut c, compressed)?);
             h.push(p);
         }
         let pk = Self { w, h0, h };
@@ -224,8 +218,7 @@ impl DeterministicPublicKey {
         }
         let mc_bytes = (message_count as u32).to_be_bytes();
         let mut data = Vec::with_capacity(9 + G2_UNCOMPRESSED_SIZE);
-        self.0
-            .serialize(&mut data, false)?;
+        self.0.serialize(&mut data, false)?;
         // Spacer
         data.push(0u8);
         let offset = data.len();

--- a/libzmix/bbs/src/lib.rs
+++ b/libzmix/bbs/src/lib.rs
@@ -396,8 +396,7 @@ impl BlindSignatureContext {
 
         let end = g1_size + FR_COMPRESSED_SIZE;
 
-        let challenge_hash =
-            ProofChallenge(slice_to_elem!(&mut cursor, Fr, compressed)?);
+        let challenge_hash = ProofChallenge(slice_to_elem!(&mut cursor, Fr, compressed)?);
 
         let proof_of_hidden_messages = ProofG1::from_bytes(&data[end..], g1_size, compressed)?;
         Ok(Self {

--- a/libzmix/bbs/src/lib.rs
+++ b/libzmix/bbs/src/lib.rs
@@ -392,20 +392,12 @@ impl BlindSignatureContext {
             )));
         }
 
-        let commitment = Commitment(slice_to_elem!(&mut cursor, G1, compressed).map_err(|e| {
-            BBSError::from_kind(BBSErrorKind::PoKVCError {
-                msg: format!("{}", e),
-            })
-        })?);
+        let commitment = Commitment(slice_to_elem!(&mut cursor, G1, compressed)?);
 
         let end = g1_size + FR_COMPRESSED_SIZE;
 
         let challenge_hash =
-            ProofChallenge(slice_to_elem!(&mut cursor, Fr, compressed).map_err(|e| {
-                BBSError::from_kind(BBSErrorKind::PoKVCError {
-                    msg: format!("{}", e),
-                })
-            })?);
+            ProofChallenge(slice_to_elem!(&mut cursor, Fr, compressed)?);
 
         let proof_of_hidden_messages = ProofG1::from_bytes(&data[end..], g1_size, compressed)?;
         Ok(Self {
@@ -601,10 +593,7 @@ impl SignatureProof {
         }
 
         let proof_len = u32::from_be_bytes(*array_ref![data, 0, 4]) as usize + 4;
-        let proof = PoKOfSignatureProof::from_bytes(&data[4..proof_len], g1_size, compressed)
-            .map_err(|e| BBSErrorKind::GeneralError {
-                msg: format!("{:?}", e),
-            })?;
+        let proof = PoKOfSignatureProof::from_bytes(&data[4..proof_len], g1_size, compressed)?;
 
         let mut offset = proof_len;
         let revealed_messages_len = u32::from_be_bytes(*array_ref![data, offset, 4]) as usize;

--- a/libzmix/bbs/src/macros.rs
+++ b/libzmix/bbs/src/macros.rs
@@ -20,11 +20,7 @@ macro_rules! from_impl {
 
             fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
                 let mut value = value;
-                let inner = $type::deserialize(&mut value, true).map_err(|e| {
-                    BBSErrorKind::GeneralError {
-                        msg: format!("{:?}", e),
-                    }
-                })?;
+                let inner = $type::deserialize(&mut value, true)?;
                 Ok(Self(inner))
             }
         }
@@ -67,10 +63,7 @@ macro_rules! from_impl {
             type Error = BBSError;
 
             fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-                let inner = $type::deserialize(&mut value.as_ref(), value.len() == $comp_size)
-                    .map_err(|_| BBSErrorKind::GeneralError {
-                        msg: "Invalid bytes".to_string(),
-                    })?;
+                let inner = $type::deserialize(&mut value.as_ref(), value.len() == $comp_size)?;
                 Ok(Self(inner))
             }
         }

--- a/libzmix/bbs/src/pok_sig.rs
+++ b/libzmix/bbs/src/pok_sig.rs
@@ -478,8 +478,7 @@ impl PoKOfSignatureProof {
 
         offset = end;
         end = offset + proof1_bytes;
-        let proof_vc_1 =
-            ProofG1::from_bytes(&data[offset..end], g1_size, compressed)?;
+        let proof_vc_1 = ProofG1::from_bytes(&data[offset..end], g1_size, compressed)?;
 
         let proof_vc_2 = ProofG1::from_bytes(&data[end..], g1_size, compressed)?;
         Ok(Self {

--- a/libzmix/bbs/src/pok_sig.rs
+++ b/libzmix/bbs/src/pok_sig.rs
@@ -462,28 +462,16 @@ impl PoKOfSignatureProof {
         let mut c = Cursor::new(data.as_ref());
         let mut offset;
         let mut end = g1_size;
-        let a_prime = slice_to_elem!(&mut c, G1, compressed).map_err(|e| {
-            BBSError::from_kind(BBSErrorKind::PoKVCError {
-                msg: format!("{}", e),
-            })
-        })?;
+        let a_prime = slice_to_elem!(&mut c, G1, compressed)?;
 
         offset = end;
         end = offset + g1_size;
 
-        let a_bar = slice_to_elem!(&mut c, G1, compressed).map_err(|e| {
-            BBSError::from_kind(BBSErrorKind::PoKVCError {
-                msg: format!("{}", e),
-            })
-        })?;
+        let a_bar = slice_to_elem!(&mut c, G1, compressed)?;
         offset = end;
         end = offset + g1_size;
 
-        let d = slice_to_elem!(&mut c, G1, compressed).map_err(|e| {
-            BBSError::from_kind(BBSErrorKind::PoKVCError {
-                msg: format!("{}", e),
-            })
-        })?;
+        let d = slice_to_elem!(&mut c, G1, compressed)?;
         offset = end;
         end = offset + 4;
         let proof1_bytes = u32::from_be_bytes(*array_ref![data, offset, 4]) as usize;
@@ -491,17 +479,9 @@ impl PoKOfSignatureProof {
         offset = end;
         end = offset + proof1_bytes;
         let proof_vc_1 =
-            ProofG1::from_bytes(&data[offset..end], g1_size, compressed).map_err(|e| {
-                BBSError::from_kind(BBSErrorKind::PoKVCError {
-                    msg: format!("{}", e),
-                })
-            })?;
+            ProofG1::from_bytes(&data[offset..end], g1_size, compressed)?;
 
-        let proof_vc_2 = ProofG1::from_bytes(&data[end..], g1_size, compressed).map_err(|e| {
-            BBSError::from_kind(BBSErrorKind::PoKVCError {
-                msg: format!("{}", e),
-            })
-        })?;
+        let proof_vc_2 = ProofG1::from_bytes(&data[end..], g1_size, compressed)?;
         Ok(Self {
             a_prime,
             a_bar,

--- a/libzmix/bbs/src/pok_vc.rs
+++ b/libzmix/bbs/src/pok_vc.rs
@@ -88,6 +88,12 @@ impl From<PoKVCErrorKind> for PoKVCError {
     }
 }
 
+impl From<std::io::Error> for PoKVCError {
+    fn from(err: std::io::Error) -> Self {
+        PoKVCError::from_kind(PoKVCErrorKind::GeneralError { msg: format!("{:?}", err) })
+    }
+}
+
 impl From<Context<PoKVCErrorKind>> for PoKVCError {
     fn from(inner: Context<PoKVCErrorKind>) -> Self {
         Self { inner }
@@ -354,9 +360,7 @@ impl ProofG1 {
         let mut c = Cursor::new(data);
 
         let commitment =
-            slice_to_elem!(&mut c, G1, compressed).map_err(|_| PoKVCErrorKind::GeneralError {
-                msg: format!("Invalid Length"),
-            })?;
+            slice_to_elem!(&mut c, G1, compressed)?;
 
         let mut length_bytes = [0u8; 4];
         c.read_exact(&mut length_bytes).unwrap();
@@ -372,11 +376,7 @@ impl ProofG1 {
         let mut responses = Vec::with_capacity(length);
 
         for _ in 0..length {
-            let r = slice_to_elem!(&mut c, Fr, compressed).map_err(|_| {
-                PoKVCErrorKind::GeneralError {
-                    msg: format!("Invalid length"),
-                }
-            })?;
+            let r = slice_to_elem!(&mut c, Fr, compressed)?;
             responses.push(r);
         }
         Ok(Self {

--- a/libzmix/bbs/src/pok_vc.rs
+++ b/libzmix/bbs/src/pok_vc.rs
@@ -90,7 +90,9 @@ impl From<PoKVCErrorKind> for PoKVCError {
 
 impl From<std::io::Error> for PoKVCError {
     fn from(err: std::io::Error) -> Self {
-        PoKVCError::from_kind(PoKVCErrorKind::GeneralError { msg: format!("{:?}", err) })
+        PoKVCError::from_kind(PoKVCErrorKind::GeneralError {
+            msg: format!("{:?}", err),
+        })
     }
 }
 
@@ -359,8 +361,7 @@ impl ProofG1 {
         }
         let mut c = Cursor::new(data);
 
-        let commitment =
-            slice_to_elem!(&mut c, G1, compressed)?;
+        let commitment = slice_to_elem!(&mut c, G1, compressed)?;
 
         let mut length_bytes = [0u8; 4];
         c.read_exact(&mut length_bytes).unwrap();

--- a/libzmix/bbs/src/signature.rs
+++ b/libzmix/bbs/src/signature.rs
@@ -84,21 +84,9 @@ macro_rules! try_from_impl {
             fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
                 let mut value = value;
                 let compressed = value.len() == SIGNATURE_COMPRESSED_SIZE;
-                let a = G1::deserialize(&mut value, compressed).map_err(|_| {
-                    BBSErrorKind::GeneralError {
-                        msg: "Invalid bytes".to_string(),
-                    }
-                })?;
-                let e = Fr::deserialize(&mut value, compressed).map_err(|_| {
-                    BBSErrorKind::GeneralError {
-                        msg: "Invalid bytes".to_string(),
-                    }
-                })?;
-                let s = Fr::deserialize(&mut value, compressed).map_err(|_| {
-                    BBSErrorKind::GeneralError {
-                        msg: "Invalid bytes".to_string(),
-                    }
-                })?;
+                let a = G1::deserialize(&mut value, compressed)?;
+                let e = Fr::deserialize(&mut value, compressed)?;
+                let s = Fr::deserialize(&mut value, compressed)?;
                 Ok(Self { a, e, s })
             }
         }


### PR DESCRIPTION
This removes a lot of boiler plate using `map_err` by just adding the From trait to BBSError and PoKVCError.