### PR TITLE
Fix a problem with libsodium build instructions on OSX

### DIFF
--- a/docs/build-environment.md
+++ b/docs/build-environment.md
@@ -119,9 +119,10 @@ cd libsodium-1.0.18
 make
 sudo make install
 ```
-7. Add the libsodium environment variable
+7. Add the libsodium environment variables
 ```bash
 export SODIUM_LIB_DIR=/usr/local/lib
+export SODIUM_INCLUDE_DIR=/usr/local/include
 ```
 
 ## Windows 10


### PR DESCRIPTION
Signed-off-by: Daniel Hardman <daniel.hardman@gmail.com>

On OSX, a custom build step for libsodium-ffi will fail unless SODIUM_INCLUDE_DIR env variable is also set. This is the symptom:

   Compiling libsodium-ffi v0.2.2
error: failed to run custom build command for `libsodium-ffi v0.2.2`

Caused by:
  process didn't exit successfully: `/Users/daniel/code/ursa/target/release/build/libsodium-ffi-cf690b9353f5cf0c/build-script-build` (exit code: 101)
--- stdout
cargo:rerun-if-env-changed=SODIUM_LIB_DIR
cargo:rerun-if-env-changed=SODIUM_INCLUDE_DIR
cargo:rerun-if-env-changed=SODIUM_STATIC
cargo:rerun-if-env-changed=SODIUM_BUILD_STATIC
cargo:rerun-if-env-changed=SODIUM_BUILD_INCLUDE_DIR
cargo:rustc-link-lib=dylib=sodium
cargo:rustc-link-search=native=/usr/local/lib

--- stderr
thread 'main' panicked at 'You have to provide SODIUM_LIB_DIR and SODIUM_INCLUDE_DIR together', /Users/daniel/.cargo/registry/src/github.com-1ecc6299db9ec823/libsodium-ffi-0.2.2/build.rs:85:24
