### PR TITLE
Upgrade aead/aes/aes-gcm/block-modes/chacha20poly1305 crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17,32 +17,33 @@ checksum = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
 
 [[package]]
 name = "aead"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cf01b9b56e767bb57b94ebf91a58b338002963785cdd7013e21c0d4679471e4"
+checksum = "20e6f2cedd00d6e1d33954c9e4181094b61d87e7e751e5aaed1c249df5ba71ba"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.1",
 ]
 
 [[package]]
 name = "aes"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54eb1d8fe354e5fc611daf4f2ea97dd45a765f4f1e4512306ec183ae2e8f20c9"
+checksum = "f7001367fde4c768a19d1029f0a8be5abd9308e1119846d5bd9ad26297b8faf5"
 dependencies = [
  "aes-soft",
  "aesni",
- "block-cipher-trait",
+ "block-cipher",
 ]
 
 [[package]]
 name = "aes-gcm"
-version = "0.3.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54e6fb62c3640759142eb73015f57eece23832fde0a7ccd8be17d7ccbd01f21c"
+checksum = "86f5007801316299f922a6198d1d09a0bae95786815d066d5880d13f7c45ead1"
 dependencies = [
  "aead",
  "aes",
+ "block-cipher",
  "ghash",
  "subtle 2.2.3",
  "zeroize",
@@ -50,22 +51,22 @@ dependencies = [
 
 [[package]]
 name = "aes-soft"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd7e7ae3f9a1fb5c03b389fc6bb9a51400d0c13053f0dca698c832bfd893a0d"
+checksum = "4925647ee64e5056cf231608957ce7c81e12d6d6e316b9ce1404778cc1d35fa7"
 dependencies = [
- "block-cipher-trait",
+ "block-cipher",
  "byteorder",
  "opaque-debug",
 ]
 
 [[package]]
 name = "aesni"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f70a6b5f971e473091ab7cfb5ffac6cde81666c4556751d8d5620ead8abf100"
+checksum = "d050d39b0b7688b3a3254394c3e30a9d66c41dcf9b05b0e2dbdc623f6505d264"
 dependencies = [
- "block-cipher-trait",
+ "block-cipher",
  "opaque-debug",
 ]
 
@@ -224,25 +225,25 @@ dependencies = [
  "block-padding",
  "byte-tools",
  "byteorder",
- "generic-array",
+ "generic-array 0.12.3",
 ]
 
 [[package]]
-name = "block-cipher-trait"
-version = "0.6.2"
+name = "block-cipher"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c924d49bd09e7c06003acda26cd9742e796e34282ec6c1189404dee0c1f4774"
+checksum = "f837aab23b44bf3be7e24411b599fda76b1788792e765fa077af268292e156d1"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.1",
 ]
 
 [[package]]
 name = "block-modes"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31aa8410095e39fdb732909fb5730a48d5bd7c2e3cd76bd1b07b3dbea130c529"
+checksum = "538b66bc25a51ce985544067a9c3e17d426447f468c495dd6cb00040e5953692"
 dependencies = [
- "block-cipher-trait",
+ "block-cipher",
  "block-padding",
 ]
 
@@ -363,9 +364,9 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "chacha20"
-version = "0.3.4"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6a7ae4c498f8447d86baef0fa0831909333f558866fabcb21600625ac5a31c7"
+checksum = "b6acd88fd85f945e7f2e86830a197b26baa828a623de7cd47a00c10b3a2057d7"
 dependencies = [
  "stream-cipher",
  "zeroize",
@@ -373,9 +374,9 @@ dependencies = [
 
 [[package]]
 name = "chacha20poly1305"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48901293601228db2131606f741db33561f7576b5d19c99cd66222380a7dc863"
+checksum = "803c3ae4a496c02cffe96387b35b347d97097c805d55aadfcb549caa0f3a8eb0"
 dependencies = [
  "aead",
  "chacha20",
@@ -541,7 +542,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4434400df11d95d556bac068ddfedd482915eb18fe8bea89bc80b6e4b1c179e5"
 dependencies = [
- "generic-array",
+ "generic-array 0.12.3",
  "subtle 1.0.0",
 ]
 
@@ -617,7 +618,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 dependencies = [
- "generic-array",
+ "generic-array 0.12.3",
 ]
 
 [[package]]
@@ -778,6 +779,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d2664c2cf08049036f31015b04c6ac3671379a1d86f52ed2416893f16022deb"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -790,9 +800,9 @@ dependencies = [
 
 [[package]]
 name = "ghash"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f0930ed19a7184089ea46d2fedead2f6dc2b674c5db4276b7da336c7cd83252"
+checksum = "d6e27f0689a6e15944bdce7e45425efb87eaa8ab0c6e87f11d0987a9133e2531"
 dependencies = [
  "polyval",
 ]
@@ -864,7 +874,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6e570451493f10f6581b48cdd530413b63ea9e780f544bfd3bdcaa0d89d1a7b"
 dependencies = [
  "digest",
- "generic-array",
+ "generic-array 0.12.3",
  "hmac",
 ]
 
@@ -1200,18 +1210,18 @@ checksum = "b18befed8bc2b61abc79a457295e7e838417326da1586050b919414073977f19"
 
 [[package]]
 name = "poly1305"
-version = "0.5.2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5829f50f48e9ddb79f3f7c3097029d0caee30f8286accb241416df603b080b8"
+checksum = "d9b42192ab143ed7619bf888a7f9c6733a9a2153b218e2cd557cfdb52fbf9bb1"
 dependencies = [
  "universal-hash",
 ]
 
 [[package]]
 name = "polyval"
-version = "0.3.3"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec3341498978de3bfd12d1b22f1af1de22818f5473a11e8a6ef997989e3a212"
+checksum = "d9a50142b55ab3ed0e9f68dfb3709f1d90d29da24e91033f28b96330643107dc"
 dependencies = [
  "cfg-if",
  "universal-hash",
@@ -1681,11 +1691,11 @@ dependencies = [
 
 [[package]]
 name = "stream-cipher"
-version = "0.3.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8131256a5896cabcf5eb04f4d6dacbe1aefda854b0d9896e09cb58829ec5638c"
+checksum = "97961116ec5528e0df39aa6e514377cd1572b8b4623576b371da425a87328d16"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.1",
 ]
 
 [[package]]
@@ -1817,9 +1827,9 @@ checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 
 [[package]]
 name = "universal-hash"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df0c900f2f9b4116803415878ff48b63da9edb268668e08cf9292d7503114a01"
+checksum = "8326b2c654932e3e4f9196e69d08fdf7cfd718e1dc6f66b347e6024a0c961402"
 dependencies = [
  "generic-array",
  "subtle 2.2.3",

--- a/libursa/Cargo.toml
+++ b/libursa/Cargo.toml
@@ -106,14 +106,14 @@ x25519 = ["arrayref", "curve25519-dalek/std", "curve25519-dalek/u64_backend", "h
 x25519_asm = ["arrayref", "curve25519-dalek/nightly", "curve25519-dalek/avx2_backend", "hex", "rand", "rand_chacha", "sha2/asm", "x25519-dalek/nightly", "x25519-dalek/u64_backend", "zeroize"]
 
 [dependencies]
-aead = { version = "0.2", optional = true }
-aes = { version = "0.3", optional = true }
-aes-gcm = { version = "0.3.0", optional = true }
+aead = { version = "0.3", optional = true }
+aes = { version = "0.4", optional = true }
+aes-gcm = { version = "0.6.0", optional = true }
 amcl = { version = "0.2",  optional = true, default-features = false, features = ["bn254", "secp256k1"]}
 amcl_wrapper = {version = "0.3.5", features = ["bls381"], optional = true }
 arrayref = { version = "0.3.5", optional = true }
 blake2 = { version = "0.8", default-features = false, optional = true }
-block-modes = { version = "0.3", optional = true }
+block-modes = { version = "0.4", optional = true }
 block-padding = { version = "0.1", optional = true }
 clear_on_drop = { version = "0.2.3", optional = true }
 console_error_panic_hook = { version = "0.1.5", optional = true }
@@ -137,7 +137,7 @@ openssl = { version = "0.10", optional = true }
 # TODO: Find out if the wasm-bindgen feature can be made dependent on our own wasm feature
 rand = { version = "=0.6.5", features = ["wasm-bindgen"], optional = true }
 rand_chacha = { version = "=0.1.1", optional = true }
-rustchacha20poly1305 = { version = "0.4.1", package = "chacha20poly1305", optional = true }
+rustchacha20poly1305 = { version = "0.5.0", package = "chacha20poly1305", optional = true }
 rustlibsecp256k1 = { version = "0.3", package = "libsecp256k1", optional = true }
 secp256k1 = { version = "0.17", optional = true, features = ["rand", "serde"]}
 serde = { version = "1.0", features = ["derive"],  optional = true}

--- a/libursa/src/encryption/symm/aescbc.rs
+++ b/libursa/src/encryption/symm/aescbc.rs
@@ -35,8 +35,8 @@ macro_rules! aes_cbc_hmac_impl {
         impl NewAead for $name {
             type KeySize = $keysize;
 
-            fn new(key: GenericArray<u8, $keysize>) -> Self {
-                Self { key }
+            fn new(key: &GenericArray<u8, $keysize>) -> Self {
+                Self { key: *key }
             }
         }
 
@@ -98,27 +98,6 @@ macro_rules! aes_cbc_hmac_impl {
                 } else {
                     Err(Error)
                 }
-            }
-
-            // TODO
-            fn encrypt_in_place_detached(
-                &self,
-                _nonce: &GenericArray<u8, Self::NonceSize>,
-                _associated_data: &[u8],
-                _buffer: &mut [u8],
-            ) -> Result<GenericArray<u8, Self::TagSize>, Error> {
-                unimplemented!();
-            }
-
-            // TODO
-            fn decrypt_in_place_detached(
-                &self,
-                _nonce: &GenericArray<u8, Self::NonceSize>,
-                _associated_data: &[u8],
-                _buffer: &mut [u8],
-                _tag: &GenericArray<u8, Self::TagSize>,
-            ) -> Result<(), Error> {
-                unimplemented!();
             }
         }
 

--- a/libursa/src/encryption/symm/aescbc_asm.rs
+++ b/libursa/src/encryption/symm/aescbc_asm.rs
@@ -31,8 +31,8 @@ macro_rules! aes_cbc_hmac_impl {
         impl NewAead for $name {
             type KeySize = $keysize;
 
-            fn new(key: GenericArray<u8, Self::KeySize>) -> Self {
-                Self { key }
+            fn new(key: &GenericArray<u8, Self::KeySize>) -> Self {
+                Self { key: *key }
             }
         }
 
@@ -101,27 +101,6 @@ macro_rules! aes_cbc_hmac_impl {
                 } else {
                     Err(Error)
                 }
-            }
-
-            // TODO
-            fn encrypt_in_place_detached(
-                &self,
-                _nonce: &GenericArray<u8, Self::NonceSize>,
-                _associated_data: &[u8],
-                _buffer: &mut [u8],
-            ) -> Result<GenericArray<u8, Self::TagSize>, Error> {
-                unimplemented!();
-            }
-
-            // TODO
-            fn decrypt_in_place_detached(
-                &self,
-                _nonce: &GenericArray<u8, Self::NonceSize>,
-                _associated_data: &[u8],
-                _buffer: &mut [u8],
-                _tag: &GenericArray<u8, Self::TagSize>,
-            ) -> Result<(), Error> {
-                unimplemented!();
             }
         }
 

--- a/libursa/src/encryption/symm/aesgcm.rs
+++ b/libursa/src/encryption/symm/aesgcm.rs
@@ -25,8 +25,8 @@ macro_rules! aes_gcm_impl {
         impl NewAead for $name {
             type KeySize = $keysize;
 
-            fn new(key: GenericArray<u8, Self::KeySize>) -> Self {
-                Self { key }
+            fn new(key: &GenericArray<u8, Self::KeySize>) -> Self {
+                Self { key: *key }
             }
         }
 
@@ -41,7 +41,7 @@ macro_rules! aes_gcm_impl {
                 plaintext: impl Into<Payload<'msg, 'aad>>,
             ) -> Result<Vec<u8>, Error> {
                 let payload = plaintext.into();
-                let aes = $algoname::new(self.key);
+                let aes = $algoname::new(&self.key);
                 aes.encrypt(nonce, payload)
             }
 
@@ -56,29 +56,8 @@ macro_rules! aes_gcm_impl {
                     return Err(Error);
                 }
 
-                let aes = $algoname::new(self.key);
+                let aes = $algoname::new(&self.key);
                 aes.decrypt(nonce, payload)
-            }
-
-            // TODO
-            fn encrypt_in_place_detached(
-                &self,
-                _nonce: &GenericArray<u8, Self::NonceSize>,
-                _associated_data: &[u8],
-                _buffer: &mut [u8],
-            ) -> Result<GenericArray<u8, Self::TagSize>, Error> {
-                unimplemented!();
-            }
-
-            // TODO
-            fn decrypt_in_place_detached(
-                &self,
-                _nonce: &GenericArray<u8, Self::NonceSize>,
-                _associated_data: &[u8],
-                _buffer: &mut [u8],
-                _tag: &GenericArray<u8, Self::TagSize>,
-            ) -> Result<(), Error> {
-                unimplemented!();
             }
         }
 

--- a/libursa/src/encryption/symm/aesgcm_asm.rs
+++ b/libursa/src/encryption/symm/aesgcm_asm.rs
@@ -27,8 +27,8 @@ macro_rules! aes_gcm_impl {
         impl NewAead for $name {
             type KeySize = $keysize;
 
-            fn new(key: GenericArray<u8, Self::KeySize>) -> Self {
-                Self { key }
+            fn new(key: &GenericArray<u8, Self::KeySize>) -> Self {
+                Self { key: *key }
             }
         }
 
@@ -80,27 +80,6 @@ macro_rules! aes_gcm_impl {
                 )
                 .map_err(|_| Error)?;
                 Ok(plaintext)
-            }
-
-            // TODO
-            fn encrypt_in_place_detached(
-                &self,
-                _nonce: &GenericArray<u8, Self::NonceSize>,
-                _associated_data: &[u8],
-                _buffer: &mut [u8],
-            ) -> Result<GenericArray<u8, Self::TagSize>, Error> {
-                unimplemented!();
-            }
-
-            // TODO
-            fn decrypt_in_place_detached(
-                &self,
-                _nonce: &GenericArray<u8, Self::NonceSize>,
-                _associated_data: &[u8],
-                _buffer: &mut [u8],
-                _tag: &GenericArray<u8, Self::TagSize>,
-            ) -> Result<(), Error> {
-                unimplemented!();
             }
         }
 

--- a/libursa/src/encryption/symm/chacha20poly1305.rs
+++ b/libursa/src/encryption/symm/chacha20poly1305.rs
@@ -23,8 +23,8 @@ impl Encryptor for ChaCha20Poly1305 {
 impl NewAead for ChaCha20Poly1305 {
     type KeySize = U32;
 
-    fn new(key: GenericArray<u8, Self::KeySize>) -> Self {
-        Self { key }
+    fn new(key: &GenericArray<u8, Self::KeySize>) -> Self {
+        Self { key: *key }
     }
 }
 
@@ -38,7 +38,7 @@ impl Aead for ChaCha20Poly1305 {
         nonce: &GenericArray<u8, Self::NonceSize>,
         plaintext: impl Into<Payload<'msg, 'aad>>,
     ) -> Result<Vec<u8>, Error> {
-        let aead = SysChaCha20Poly1305::new(self.key.clone());
+        let aead = SysChaCha20Poly1305::new(&self.key);
         let ciphertext = aead.encrypt(nonce, plaintext)?;
         Ok(ciphertext)
     }
@@ -48,30 +48,9 @@ impl Aead for ChaCha20Poly1305 {
         nonce: &GenericArray<u8, Self::NonceSize>,
         ciphertext: impl Into<Payload<'msg, 'aad>>,
     ) -> Result<Vec<u8>, Error> {
-        let aead = SysChaCha20Poly1305::new(self.key.clone());
+        let aead = SysChaCha20Poly1305::new(&self.key);
         let plaintext = aead.decrypt(nonce, ciphertext)?;
         Ok(plaintext)
-    }
-
-    // TODO
-    fn encrypt_in_place_detached(
-        &self,
-        _nonce: &GenericArray<u8, Self::NonceSize>,
-        _associated_data: &[u8],
-        _buffer: &mut [u8],
-    ) -> Result<GenericArray<u8, Self::TagSize>, Error> {
-        unimplemented!();
-    }
-
-    // TODO
-    fn decrypt_in_place_detached(
-        &self,
-        _nonce: &GenericArray<u8, Self::NonceSize>,
-        _associated_data: &[u8],
-        _buffer: &mut [u8],
-        _tag: &GenericArray<u8, Self::TagSize>,
-    ) -> Result<(), Error> {
-        unimplemented!();
     }
 }
 

--- a/libursa/src/encryption/symm/chacha20poly1305_asm.rs
+++ b/libursa/src/encryption/symm/chacha20poly1305_asm.rs
@@ -31,14 +31,14 @@ impl Encryptor for ChaCha20Poly1305 {
 impl NewAead for ChaCha20Poly1305 {
     type KeySize = U32;
 
-    fn new(key: GenericArray<u8, Self::KeySize>) -> Self {
+    fn new(key: &GenericArray<u8, Self::KeySize>) -> Self {
         if !INIT.load(Ordering::Relaxed) {
             INIT.store(true, Ordering::Release);
             unsafe {
                 libsodium_ffi::sodium_init();
             }
         }
-        Self { key }
+        Self { key: *key }
     }
 }
 
@@ -103,27 +103,6 @@ impl Aead for ChaCha20Poly1305 {
             plaintext.set_len(plen as usize);
         }
         Ok(plaintext)
-    }
-
-    // TODO
-    fn encrypt_in_place_detached(
-        &self,
-        _nonce: &GenericArray<u8, Self::NonceSize>,
-        _associated_data: &[u8],
-        _buffer: &mut [u8],
-    ) -> Result<GenericArray<u8, Self::TagSize>, Error> {
-        unimplemented!();
-    }
-
-    // TODO
-    fn decrypt_in_place_detached(
-        &self,
-        _nonce: &GenericArray<u8, Self::NonceSize>,
-        _associated_data: &[u8],
-        _buffer: &mut [u8],
-        _tag: &GenericArray<u8, Self::TagSize>,
-    ) -> Result<(), Error> {
-        unimplemented!();
     }
 }
 

--- a/libursa/src/encryption/symm/xchacha20poly1305.rs
+++ b/libursa/src/encryption/symm/xchacha20poly1305.rs
@@ -23,8 +23,8 @@ impl Encryptor for XChaCha20Poly1305 {
 impl NewAead for XChaCha20Poly1305 {
     type KeySize = U32;
 
-    fn new(key: GenericArray<u8, Self::KeySize>) -> Self {
-        Self { key }
+    fn new(key: &GenericArray<u8, Self::KeySize>) -> Self {
+        Self { key: *key }
     }
 }
 
@@ -38,7 +38,7 @@ impl Aead for XChaCha20Poly1305 {
         nonce: &GenericArray<u8, Self::NonceSize>,
         plaintext: impl Into<Payload<'msg, 'aad>>,
     ) -> Result<Vec<u8>, Error> {
-        let aead = SysXChaCha20Poly1305::new(self.key.clone());
+        let aead = SysXChaCha20Poly1305::new(&self.key);
         let ciphertext = aead.encrypt(nonce, plaintext)?;
         Ok(ciphertext)
     }
@@ -48,30 +48,9 @@ impl Aead for XChaCha20Poly1305 {
         nonce: &GenericArray<u8, Self::NonceSize>,
         ciphertext: impl Into<Payload<'msg, 'aad>>,
     ) -> Result<Vec<u8>, Error> {
-        let aead = SysXChaCha20Poly1305::new(self.key.clone());
+        let aead = SysXChaCha20Poly1305::new(&self.key);
         let plaintext = aead.decrypt(nonce, ciphertext)?;
         Ok(plaintext)
-    }
-
-    // TODO
-    fn encrypt_in_place_detached(
-        &self,
-        _nonce: &GenericArray<u8, Self::NonceSize>,
-        _associated_data: &[u8],
-        _buffer: &mut [u8],
-    ) -> Result<GenericArray<u8, Self::TagSize>, Error> {
-        unimplemented!();
-    }
-
-    // TODO
-    fn decrypt_in_place_detached(
-        &self,
-        _nonce: &GenericArray<u8, Self::NonceSize>,
-        _associated_data: &[u8],
-        _buffer: &mut [u8],
-        _tag: &GenericArray<u8, Self::TagSize>,
-    ) -> Result<(), Error> {
-        unimplemented!();
     }
 }
 

--- a/libursa/src/encryption/symm/xchacha20poly1305_asm.rs
+++ b/libursa/src/encryption/symm/xchacha20poly1305_asm.rs
@@ -31,14 +31,14 @@ impl Encryptor for XChaCha20Poly1305 {
 impl NewAead for XChaCha20Poly1305 {
     type KeySize = U32;
 
-    fn new(key: GenericArray<u8, Self::KeySize>) -> Self {
+    fn new(key: &GenericArray<u8, Self::KeySize>) -> Self {
         if !INIT.load(Ordering::Relaxed) {
             INIT.store(true, Ordering::Release);
             unsafe {
                 libsodium_ffi::sodium_init();
             }
         }
-        Self { key }
+        Self { key: *key }
     }
 }
 
@@ -103,27 +103,6 @@ impl Aead for XChaCha20Poly1305 {
             plaintext.set_len(plen as usize);
         }
         Ok(plaintext)
-    }
-
-    // TODO
-    fn encrypt_in_place_detached(
-        &self,
-        _nonce: &GenericArray<u8, Self::NonceSize>,
-        _associated_data: &[u8],
-        _buffer: &mut [u8],
-    ) -> Result<GenericArray<u8, Self::TagSize>, Error> {
-        unimplemented!();
-    }
-
-    // TODO
-    fn decrypt_in_place_detached(
-        &self,
-        _nonce: &GenericArray<u8, Self::NonceSize>,
-        _associated_data: &[u8],
-        _buffer: &mut [u8],
-        _tag: &GenericArray<u8, Self::TagSize>,
-    ) -> Result<(), Error> {
-        unimplemented!();
     }
 }
 


### PR DESCRIPTION
Updates the following crates:

- `aead` => v0.3
- `aes` => v0.4
- `aes-gcm` => v0.6.0
- `block-modes` => v0.4
- `chacha20poly1305` => v0.5.0

Some `aead` v0.3 update notes:

- `NewAead` now borrows the key, preventing unnecessary copies
- `Aead` and `AeadInPlace` were split into two different traits. This lets you get rid of the stubbed out `*_in_place*` methods on your `Aead` impls (introduced in #91)

More release notes here: https://github.com/RustCrypto/traits/pull/174

The other crate updates use the new traits and also upgrade `generic-array` to v0.14, which has MSRV 1.41+.

Signed-off-by: Tony Arcieri <bascule@gmail.com>