### PR TITLE
Turn on issues

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -8,7 +8,7 @@ repository:
   homepage: https://wiki.hyperledger.org/display/ursa
   default_branch: master
   has_downloads: true
-  has_issues: false
+  has_issues: true
   has_projects: false
   has_wiki: false
   archived: false


### PR DESCRIPTION
this PR turns on issues for the ursa repo so that we can use them to track work items, concerns, and other tasks.