### PR TITLE
Update `rand_chacha` to `=0.2.1`

### DIFF
--- a/libursa/Cargo.toml
+++ b/libursa/Cargo.toml
@@ -136,7 +136,7 @@ num-traits = { version = "=0.2.11", optional = true }
 openssl = { version = "0.10", optional = true }
 # TODO: Find out if the wasm-bindgen feature can be made dependent on our own wasm feature
 rand = { version = "=0.7", features = ["wasm-bindgen"], optional = true }
-rand_chacha = { version = "=0.2.0", optional = true }
+rand_chacha = { version = "=0.2.1", optional = true }
 rustchacha20poly1305 = { version = "0.5.0", package = "chacha20poly1305", optional = true }
 rustlibsecp256k1 = { version = "0.3", package = "libsecp256k1", optional = true }
 secp256k1 = { version = "0.17", optional = true, features = ["rand", "serde"]}


### PR DESCRIPTION
The latest version of [substrate](https://github.com/paritytech/substrate) libraries depend on the `rand` crate version 0.7.3, which depends on at least `rand_chacha` crate version 0.2.1, this makes a conflict when using it with the latest `ursa` crate. Therefore this PR is meant to fix that and make the latest `ursa` and `substrate` compatible, as they have intersecting groups of users.

Signed-off-by: Vladislav Markushin <negigic@gmail.com>