### PR TITLE
ed25519-dalek to stable 1.0.0 release with legacy_support

### DIFF
--- a/libursa/Cargo.toml
+++ b/libursa/Cargo.toml
@@ -122,7 +122,7 @@ block-padding = { version = "0.1", optional = true }
 clear_on_drop = { version = "0.2.4", optional = true }
 console_error_panic_hook = { version = "0.1.5", optional = true }
 curve25519-dalek = { version = "2.0.0", default-features = false, optional = true }
-ed25519-dalek = { version = "=1.0.0-pre.3", default-features = false, optional = true }
+ed25519-dalek = { version = "=1.0.0-pre.3", default-features = false, optional = true, features = ["legacy_compatibility"]}
 env_logger = { version = "0.7.0", optional = true }
 failure = { version = "0.1.6", optional = true }
 ffi-support = { version = "0.4", optional = true }


### PR DESCRIPTION
Bumped ed25519-dalek crate version to 1.0.0 release with `features = ["legacy_compatibility"]` feature to preserve compatibility with libsodium.

Details: [Crate Documentation](https://docs.rs/crate/ed25519-dalek/1.0.0)