### PR TITLE
adding CII best practices badge status

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Build Status](https://dev.azure.com/Hyperledger/Ursa/_apis/build/status/hyperledger.ursa?branchName=master)](https://dev.azure.com/Hyperledger/Ursa/_build/latest?definitionId=66&branchName=master)
 [![Build status](https://ci.appveyor.com/api/projects/status/1htmp82mdvmfjjap?svg=true)](https://ci.appveyor.com/project/hyperledger/ursa)
+[![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/2447/badge)](https://bestpractices.coreinfrastructure.org/projects/2447)
 
 - [Introduction](#introduction)
 - [Features](#features)


### PR DESCRIPTION
Signed-off-by: Dave Huseby <dhuseby@linuxfoundation.org>

One of the CII best practices requirements is clearly self serving in that it requires us to display our CII badge on our website. OK. Here it is.