### PR TITLE
Fixes a compile warning from cargo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,6 @@
+[profile.release]
+lto = true
+
 [workspace]
 members = [
   "libursa",

--- a/libursa/Cargo.toml
+++ b/libursa/Cargo.toml
@@ -34,9 +34,6 @@ name = "ursa"
 path = "src/lib.rs"
 crate-type = ["staticlib", "rlib", "cdylib"]
 
-[profile.release]
-lto = true
-
 [[bin]]
 name = "test_aescbc"
 path = "bin/test_aescbc.rs"


### PR DESCRIPTION
Signed-off-by: Dave Huseby <dhuseby@linuxfoundation.org>

profiles can only be at the workspace level. they are ignored otherwise which is what the warning is about:

https://doc.rust-lang.org/cargo/reference/profiles.html