### PR TITLE
Run libursa tests on Ubuntu 20.04

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,6 +40,11 @@ jobs:
     - name: Tests
       run: cargo test --release
 
+    - name: Libursa Build
+      run: cargo build --verbose --manifest-path=libursa/Cargo.toml
+
+    - name: Libursa Tests
+      run: cargo test --release --verbose --manifest-path=libursa/Cargo.toml
 # disabled in AZP
 #
 #  Portable:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,12 +39,6 @@ jobs:
 
     - name: Tests
       run: cargo test --release
-
-    - name: Libursa Build
-      run: cargo build --verbose --manifest-path=libursa/Cargo.toml
-
-    - name: Libursa Tests
-      run: cargo test --release --manifest-path=libursa/Cargo.toml
 # disabled in AZP
 #
 #  Portable:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,7 +44,7 @@ jobs:
       run: cargo build --verbose --manifest-path=libursa/Cargo.toml
 
     - name: Libursa Tests
-      run: cargo test --release --verbose --manifest-path=libursa/Cargo.toml
+      run: cargo test --release --manifest-path=libursa/Cargo.toml
 # disabled in AZP
 #
 #  Portable:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,6 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 lto = true
 
 [workspace]
-exclude = [
-    "libursa",
-    "libzmix",
-]
 members = [
     "ursa_accumulators",
     "ursa_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,10 @@ crate-type = ["cdylib", "staticlib", "rlib"]
 lto = true
 
 [workspace]
+exclude = [
+    "libursa",
+    "libzmix",
+]
 members = [
     "ursa_accumulators",
     "ursa_core",

--- a/libursa/src/errors/mod.rs
+++ b/libursa/src/errors/mod.rs
@@ -89,7 +89,7 @@ impl fmt::Display for UrsaCryptoError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut first = true;
 
-        for cause in Fail::iter_chain(&self.inner) {
+        for cause in <dyn Fail>::iter_chain(&self.inner) {
             if first {
                 first = false;
                 writeln!(f, "Error: {}", cause)?;

--- a/libursa/src/kex/secp256k1.rs
+++ b/libursa/src/kex/secp256k1.rs
@@ -228,20 +228,19 @@ mod tests {
 
     #[test]
     fn secp256k1_compatibility() {
-        use libsecp256k1::{
-            ecdh::SharedSecret,
-            key::{PublicKey, SecretKey},
+          use k256::{
+            {PublicKey, SecretKey},
+            elliptic_curve::ecdh::diffie_hellman,
         };
 
         let scheme = EcdhSecp256k1Sha256::new();
         let (pk, sk) = scheme.keypair(None).unwrap();
-
-        let sk1 = SecretKey::from_slice(&sk[..]).unwrap();
-        let pk1 = PublicKey::from_slice(&pk[..]).unwrap();
-        let secret = SharedSecret::new(&pk1, &sk1);
+        let sk1 = SecretKey::from_bytes(&sk[..]).unwrap();
+        let pk1 = PublicKey::from_sec1_bytes(&pk[..]).unwrap();
+        let secret = diffie_hellman(sk1.secret_scalar(), pk1.as_affine());
         assert_eq!(
-            secret.as_ref(),
-            scheme.compute_shared_secret(&sk, &pk).unwrap().as_ref()
+            secret.as_bytes().to_vec(),
+            scheme.compute_shared_secret(&sk, &pk).unwrap().as_ref().to_vec()
         );
     }
 }

--- a/libursa/src/kex/secp256k1.rs
+++ b/libursa/src/kex/secp256k1.rs
@@ -130,8 +130,6 @@ mod ecdh_secp256k1 {
     use sha2::digest::generic_array::typenum::U32;
     use sha2::Digest;
     use zeroize::Zeroize;
-    #[allow(dead_code)]
-    const PUBLIC_UNCOMPRESSED_KEY_SIZE: usize = 65;
 
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
     pub struct EcdhSecp256k1Impl;

--- a/libursa/src/kex/secp256k1.rs
+++ b/libursa/src/kex/secp256k1.rs
@@ -228,7 +228,7 @@ mod tests {
 
     #[test]
     fn secp256k1_compatibility() {
-          use k256::{
+        use k256::{
             {PublicKey, SecretKey},
             elliptic_curve::ecdh::diffie_hellman,
         };

--- a/libursa/src/kex/secp256k1.rs
+++ b/libursa/src/kex/secp256k1.rs
@@ -130,6 +130,7 @@ mod ecdh_secp256k1 {
     use sha2::digest::generic_array::typenum::U32;
     use sha2::Digest;
     use zeroize::Zeroize;
+    #[allow(dead_code)]
     const PUBLIC_UNCOMPRESSED_KEY_SIZE: usize = 65;
 
     #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]

--- a/libursa/src/signatures/ed25519.rs
+++ b/libursa/src/signatures/ed25519.rs
@@ -262,7 +262,7 @@ mod test {
                 assert!(result.is_ok());
                 assert!(result.unwrap());
             }
-            Err(e) => assert!(false, e),
+            Err(e) => assert!(false, "{}", e),
         }
         let signer = Signer::new(&scheme, &s);
         match signer.sign(&MESSAGE_1) {
@@ -271,7 +271,7 @@ mod test {
                 assert!(result.is_ok());
                 assert!(result.unwrap());
             }
-            Err(er) => assert!(false, er),
+            Err(er) => assert!(false, "{}", er),
         }
     }
 

--- a/libursa/src/signatures/secp256k1.rs
+++ b/libursa/src/signatures/secp256k1.rs
@@ -472,7 +472,7 @@ mod test {
                         assert!(result.is_ok());
                         assert!(result.unwrap());
                     }
-                    Err(er) => assert!(false, er),
+                    Err(er) => assert!(false, "{}", er),
                 }
 
                 let signer = Signer::new(&scheme, &s);
@@ -482,10 +482,10 @@ mod test {
                         assert!(result.is_ok());
                         assert!(result.unwrap());
                     }
-                    Err(er) => assert!(false, er),
+                    Err(er) => assert!(false, "{}", er),
                 }
             }
-            Err(e) => assert!(false, e),
+            Err(e) => assert!(false, "{}", e),
         }
     }
 


### PR DESCRIPTION
This PR adds `libursa`-specific jobs to GH Actions (namely building `libursa` and running its tests).

One thing I'm not sure about is the workaround for getting `libursa` to build on its own -- currently, running `cargo build` in the `libursa` directory on the `main` branch will yield this error:
```
error: current package believes it's in a workspace when it's not:
current:   ursa/libursa/Cargo.toml
workspace: ursa/Cargo.toml

this may be fixable by adding `libursa` to the `workspace.members` array of the manifest located at: ursa/Cargo.toml
Alternatively, to keep it out of the workspace, add the package to the `workspace.exclude` array, or add an empty `[workspace]` table to the package's manifest.
```
I heeded the second suggestion and excluded `libzmix` and `libursa` from the workspace, but I'm not sure if this is the correct course of action. Feel free to request/make changes!

As for the changes to `libursa/src/kex/secp256k1.rs`, the compatibility test was never updated after `libsecp256k1` was replaced with `k256` in #171, so this PR also fixes that.
