### PR TITLE
Adding Aleksandr Petrosyan as a maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,5 +4,7 @@
 | name         | Github                                         | Discord        |
 |--------------|------------------------------------------------|----------------|
 | Brent Zundel | [@brentzundel](https://github.com/brentzundel) | brent#0347     |
+ | Aleksandr Petrosyan | [@a-p-petrosyan](https://github.com/a-p-petrosyan) | a-p-petrosyan#9734 |
 | Mike Lodder  | [@mikelodder7](https://github.com/mikelodder7) | -              |
 | Cam Parra    | [@mac-arrap](https://github.com/mac-arrap)     | cam-parra#1919 |
+


### PR DESCRIPTION
Signed-off-by: Brent Zundel <brent.zundel@gmail.com>