### PR TITLE
fix: typo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 authors = ["The Hyperledger Ursa Contributors"]
 description = "A collection of cryptography primitives for implementing blockchain transactions and secure communication"
-documentation = "https://doc.rs/ursa"
+documentation = "https://docs.rs/ursa"
 edition = "2018"
 homepage = "https://crates.io/crates/ursa"
 keywords = ["cryptography", "zero-knowledge"]


### PR DESCRIPTION
fix typo in https://docs.rs/ursa

Signed-off-by: Doug A <douganderson444@gmail.com>