### PR TITLE
[feature] #224: Ursa bump to  edition 2021 and trivial dependencies

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,7 @@ jobs:
         workdir: [ ".", "./libursa" ]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Build
       working-directory: ${{ matrix.workdir }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,30 +26,37 @@ jobs:
     - name: Build
       working-directory: ${{ matrix.workdir }}
       run: cargo build --verbose
+      if: always()
 
     - name: Format
       working-directory: ${{ matrix.workdir }}
       run: cargo fmt --all -- --check
+      if: always()
 
     - name: Docs
       working-directory: ${{ matrix.workdir }}
       run: cargo doc --no-deps
+      if: always()
 
     - name: Clippy
       working-directory: ${{ matrix.workdir }}
       run: cargo clippy --all -- -W clippy::not_unsafe_ptr_arg_deref -A clippy::many_single_char_names
+      if: always()
 
     - name: Check
       working-directory: ${{ matrix.workdir }}
       run: cargo check
+      if: always()
 
     - name: Tests
       working-directory: ${{ matrix.workdir }}
       run: cargo test --release
+      if: always()
 
     - name: Audit
       working-directory: ${{ matrix.workdir }}
       run: cargo audit
+      if: always()
 
 # disabled in AZP
 #

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "224afbd727c3d6e4b90103ece64b8d1b67fbb1973b1046c2281eed3f3803f800"
 
 [[package]]
 name = "autocfg"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bitflags"
@@ -66,9 +66,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cc"
-version = "1.0.72"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a9137b95ea06864e018375b72adfb7db6e6f68cfc8df5a04d00288050485ee"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cfg-if"
@@ -93,9 +93,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.2.0"
+version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
+checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
 dependencies = [
  "byteorder",
  "digest 0.9.0",
@@ -119,7 +119,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.5",
+ "generic-array 0.14.6",
 ]
 
 [[package]]
@@ -131,7 +131,7 @@ dependencies = [
  "bitvec",
  "const-oid",
  "ff",
- "generic-array 0.14.5",
+ "generic-array 0.14.6",
  "group",
  "rand_core 0.5.1",
  "subtle",
@@ -218,9 +218,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
@@ -256,9 +256,9 @@ checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "k256"
@@ -272,9 +272,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.112"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "memchr"
@@ -295,9 +295,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
  "num-traits",
@@ -305,18 +305,18 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.9.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "opaque-debug"
@@ -326,23 +326,35 @@ checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "openssl"
-version = "0.10.38"
+version = "0.10.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
+checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
  "once_cell",
+ "openssl-macros",
  "openssl-sys",
 ]
 
 [[package]]
-name = "openssl-sys"
-version = "0.9.72"
+name = "openssl-macros"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e46109c383602735fa0a2e48dd2b7c892b048e1bf69e5c3b1d804b7d9c203cb"
+checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
 dependencies = [
  "autocfg",
  "cc",
@@ -377,30 +389,30 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.24"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
+checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.14"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -500,15 +512,15 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.13"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "serde"
-version = "1.0.156"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "314b5b092c0ade17c00142951e50ced110ec27cea304b1037c6969246c2469a4"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 
 [[package]]
 name = "serde_bare"
@@ -531,9 +543,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.94"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c533a59c9d8a93a09c6ab31f0fd5e5f4dd1b8fc9434804029839884765d04ea"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
  "itoa",
  "ryu",
@@ -566,13 +578,13 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.85"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -589,18 +601,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.39"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ab016db510546d856297882807df8da66a16fb8c4101cb8b30054b0d5b2d9c"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.39"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5420d42e90af0c38c3290abcca25b9b3bdf379fc9f55c528f53a269d9c9a267e"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -609,15 +621,21 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "ursa"
@@ -744,9 +762,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize_derive"
-version = "1.2.2"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65f1a51723ec88c66d5d1fe80c841f17f63587d6691901d66be9bec6c3b51f73"
+checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/libursa/Cargo.lock
+++ b/libursa/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.17.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
 dependencies = [
  "gimli",
 ]
@@ -73,9 +73,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.18"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
@@ -117,18 +117,9 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.1.19",
  "libc",
  "winapi",
-]
-
-[[package]]
-name = "autocfg"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dde43e75fd43e8a1bf86103336bc699aa8d17ad1be60c76c0bdfd4828e19b78"
-dependencies = [
- "autocfg 1.1.0",
 ]
 
 [[package]]
@@ -139,9 +130,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "backtrace"
-version = "0.3.66"
+version = "0.3.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cab84319d616cfb654d03394f38ab7e6f0919e181b1b57e1fd15e7fb4077d9a7"
+checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
 dependencies = [
  "addr2line",
  "cc",
@@ -153,6 +144,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+
+[[package]]
+name = "base64ct"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,13 +163,11 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "blake2"
-version = "0.9.2"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4e37d16930f5459780f5621038b6382b9bb37c19016f39fb6b5808d831f174"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "crypto-mac 0.8.0",
- "digest 0.9.0",
- "opaque-debug 0.3.0",
+ "digest 0.10.6",
 ]
 
 [[package]]
@@ -187,7 +188,15 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding 0.2.1",
+ "generic-array 0.14.6",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
+dependencies = [
  "generic-array 0.14.6",
 ]
 
@@ -217,15 +226,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
-name = "bstr"
-version = "0.2.17"
+name = "block-padding"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3569f383e8f1598449f1a423e72e99569137b47740b1da11ef19af3d5c3223"
+checksum = "0a90ec2df9600c28a01c56c4784c9207a96d2451833aeceb8cc97e4c9548bb78"
 dependencies = [
- "lazy_static",
- "memchr",
- "regex-automata",
- "serde",
+ "generic-array 0.14.6",
 ]
 
 [[package]]
@@ -242,9 +248,9 @@ checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "bytebuffer-rs"
-version = "0.3.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd71ac7b1de8c3d51bb8ab0f7176ed8a1d839f56586bd5b37405c8034850c90f"
+checksum = "7f886e3b67584ff14b8dad58cecacda61c45b82ad9c9a4d71fa7d8e751bd3e96"
 dependencies = [
  "byteorder",
 ]
@@ -281,9 +287,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.0.73"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cfg-if"
@@ -355,15 +361,24 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.6.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6f2aa4d0537bcc1c74df8755072bd31c1ef1a3a1b85a68e8404a8c353b7b8b"
+checksum = "cec318a675afcb6a1ea1d4340e2d377e56e47c266f28043ceccbf4412ddfdd3b"
+
+[[package]]
+name = "core2"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.2"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
+checksum = "28d997bd5e24a5928dd43e46dc529867e207907fe0b239c3477d924f7f2ca320"
 dependencies = [
  "libc",
 ]
@@ -433,69 +448,56 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.10"
+version = "0.9.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
+checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "cfg-if",
  "crossbeam-utils",
  "memoffset",
- "once_cell",
  "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.11"
+version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
+checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
 name = "crypto-bigint"
-version = "0.2.11"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83bd3bb4314701c568e340cd8cf78c975aa0ca79e03d3f6d1677d5b0c9c0c03"
+checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
 dependencies = [
  "generic-array 0.14.6",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
-name = "crypto-mac"
-version = "0.8.0"
+name = "crypto-common"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array 0.14.6",
- "subtle",
-]
-
-[[package]]
-name = "crypto-mac"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
-dependencies = [
- "generic-array 0.14.6",
- "subtle",
+ "typenum",
 ]
 
 [[package]]
 name = "csv"
-version = "1.1.6"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22813a6dc45b335f9bade10bf7271dc477e81113e89eb251a0bc2a8a81c536e1"
+checksum = "af91f40b7355f82b0a891f50e70399475945bb0b0da4f1700ce60761c9d3e359"
 dependencies = [
- "bstr",
  "csv-core",
- "itoa 0.4.8",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -520,9 +522,9 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "3.2.1"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f9d052967f590a76e62eb387bd0bbb1b000182c3cefe5364db6b7211651bc0"
+checksum = "0b9fdf9972b2bd6af2d913799d9ebc165ea4d2e65878e329d9c6b372c4491b61"
 dependencies = [
  "byteorder",
  "digest 0.9.0",
@@ -534,11 +536,12 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.4.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79b71cca7d95d7681a4b3b9cdf63c8dbc3730d0584c2c74e31416d64a90493f4"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
  "const-oid",
+ "zeroize",
 ]
 
 [[package]]
@@ -560,24 +563,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "ecdsa"
-version = "0.12.4"
+name = "digest"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ee23aa5b4f68c7a092b5c3beb25f50c406adc75e2363634f242f28ab255372"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+dependencies = [
+ "block-buffer 0.10.3",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12844141594ad74185a926d030f3b605f6a903b4e3fec351f3ea338ac5b7637e"
 dependencies = [
  "der",
  "elliptic-curve",
- "hmac",
- "signature",
+ "rfc6979",
+ "signature 2.0.0",
 ]
 
 [[package]]
 name = "ed25519"
-version = "1.5.2"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9c280362032ea4203659fc489832d0204ef09f247a0506f170dafcac08c369"
+checksum = "91cff35c70bba8a626e3185d8cd48cc11b5437e1a5bcd15b9b5fa3c64b6dfee7"
 dependencies = [
- "signature",
+ "signature 1.3.2",
 ]
 
 [[package]]
@@ -590,43 +604,69 @@ dependencies = [
  "ed25519",
  "rand 0.7.3",
  "serde",
- "sha2",
+ "sha2 0.9.9",
  "zeroize",
 ]
 
 [[package]]
 name = "either"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "elliptic-curve"
-version = "0.10.6"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beca177dcb8eb540133e7680baff45e7cc4d93bf22002676cec549f82343721b"
+checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
 dependencies = [
+ "base16ct",
  "crypto-bigint",
+ "der",
+ "digest 0.10.6",
  "ff",
  "generic-array 0.14.6",
  "group",
+ "hkdf",
  "pkcs8",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
+ "sec1",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "env_logger"
-version = "0.7.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
 dependencies = [
- "atty",
  "humantime",
+ "is-terminal",
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "errno"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+dependencies = [
+ "errno-dragonfly",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "errno-dragonfly"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -653,11 +693,11 @@ dependencies = [
 
 [[package]]
 name = "ff"
-version = "0.10.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f40b2dcd8bc322217a5f6559ae5f9e9d1de202a2ecee2e9eafcbece7562a4f"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
 dependencies = [
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -720,9 +760,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -743,31 +783,32 @@ dependencies = [
 
 [[package]]
 name = "gimli"
-version = "0.26.2"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22030e2c5a68ec659fde1e949a745124b48e6fa8b045b7ed5bd1fe4ccc5c4e5d"
+checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
 name = "glass_pumpkin"
-version = "0.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eac7b86325ee905c72e2cb43a80b1ebe6ea82d7f0854d669190bcdc4b927762"
+checksum = "1b44974fc56b07c428059dbe44242ea9d89f09250d77a74c941e00c0ccd471d8"
 dependencies = [
+ "core2",
  "lazy_static",
  "num-bigint",
  "num-integer",
  "num-traits",
- "rand 0.7.3",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "group"
-version = "0.10.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
 dependencies = [
  "ff",
- "rand_core 0.6.3",
+ "rand_core 0.6.4",
  "subtle",
 ]
 
@@ -787,6 +828,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hermit-abi"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -794,32 +850,27 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hkdf"
-version = "0.11.0"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01706d578d5c281058480e673ae4086a9f4710d8df1ad80a5b03e39ece5f886b"
+checksum = "791a029f6b9fc27657f6f188ec6e5e43f6911f6f878e0dc5501396e09809d437"
 dependencies = [
- "digest 0.9.0",
  "hmac",
 ]
 
 [[package]]
 name = "hmac"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "crypto-mac 0.11.1",
- "digest 0.9.0",
+ "digest 0.10.6",
 ]
 
 [[package]]
 name = "humantime"
-version = "1.3.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
-dependencies = [
- "quick-error",
-]
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "int_traits"
@@ -828,52 +879,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b33c9a5c599d67d051c4dc25eb1b6b4ef715d1763c20c85c688717a1734f204e"
 
 [[package]]
-name = "itertools"
-version = "0.10.3"
+name = "io-lifetimes"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9a9d19fa1e79b6215ff29b9d6880b706147f16e9b1dbb1e4e5947b5b02bc5e3"
+checksum = "1abeb7a0dd0f8181267ff8adc397075586500b81b28a73e8a0208b00fc170fb3"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0a45d56fe973d6db23972bf5bc46f988a4a2385deac9cc29572f09daef"
+dependencies = [
+ "hermit-abi 0.3.1",
+ "io-lifetimes",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
 dependencies = [
  "either",
 ]
 
 [[package]]
 name = "itoa"
-version = "0.4.8"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b71991ff56294aa922b450139ee08b3bfc70982c6b2c7562771375cf73542dd4"
-
-[[package]]
-name = "itoa"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
+checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
 
 [[package]]
 name = "js-sys"
-version = "0.3.59"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
+checksum = "445dde2150c55e483f3d8416706b97ec8e8237c307e5b7b4b8dd15e6af2a0730"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "k256"
-version = "0.9.6"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "903ae2481bcdfdb7b68e0a9baa4b7c9aff600b9ae2e8e5bb5833b8c91ab851ea"
+checksum = "92a55e0ff3b72c262bcf041d9e97f1b84492b68f1c1a384de2323d3dc9403397"
 dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "sha2",
+ "once_cell",
+ "sha2 0.10.6",
+ "signature 2.0.0",
 ]
 
 [[package]]
 name = "keccak"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
+checksum = "3afef3b6eff9ce9d8ff9b3601125eec7f0c8cbac7abd14f355d053fa56c98768"
+dependencies = [
+ "cpufeatures",
+]
 
 [[package]]
 name = "lazy_static"
@@ -883,15 +955,21 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.127"
+version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "505e71a4706fa491e9b1b55f51b95d4037d0821ee40131190475f692b35b009b"
+checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
 name = "libm"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fc7aa29613bd6a620df431842069224d8bc9011086b1db4c0e0cd47fa03ec9a"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
 
 [[package]]
 name = "log"
@@ -910,18 +988,18 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
 ]
 
 [[package]]
 name = "miniz_oxide"
-version = "0.5.3"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f5c75688da582b8ffc1f1799e9db273f32133c49e048f614d22ec3256773ccc"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
 dependencies = [
  "adler",
 ]
@@ -934,59 +1012,59 @@ checksum = "4330eca86d39f2b52d0481aa1e90fe21bfa61f11b0bf9b48ab95595013cefe48"
 
 [[package]]
 name = "num-bigint"
-version = "0.3.3"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6f7833f2cbf2360a6cfd58cd41a53aa7a90bd4c202f5b1c7dd2ed73c57b2c3"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "num-integer",
  "num-traits",
- "rand 0.7.3",
+ "rand 0.8.5",
 ]
 
 [[package]]
 name = "num-integer"
-version = "0.1.42"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f6ea62e9d81a77cd3ee9a2a5b9b609447857f3d358704331e4ef39eb247fcba"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "num-traits",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.2.11"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
 ]
 
 [[package]]
 name = "num_cpus"
-version = "1.13.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
 [[package]]
 name = "object"
-version = "0.29.0"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21158b2c33aa6d4561f1c0a6ea283ca92bc54802a93b263e910746d679a7eb53"
+checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.13.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "oorandom"
@@ -1008,9 +1086,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.41"
+version = "0.10.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0"
+checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1034,11 +1112,11 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.75"
+version = "0.9.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f"
+checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
 dependencies = [
- "autocfg 1.1.0",
+ "autocfg",
  "cc",
  "libc",
  "pkg-config",
@@ -1057,9 +1135,9 @@ dependencies = [
 
 [[package]]
 name = "pkcs8"
-version = "0.7.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee3ef9b64d26bad0536099c816c6734379e45bbd5f14798def6809e5cc350447"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
 dependencies = [
  "der",
  "spki",
@@ -1067,9 +1145,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.25"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
 
 [[package]]
 name = "plotters"
@@ -1092,9 +1170,9 @@ checksum = "193228616381fecdc1224c62e96946dfbc73ff4384fba576e052ff8c1bea8142"
 
 [[package]]
 name = "plotters-svg"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0918736323d1baff32ee0eade54984f6f201ad7e97d5cfb5d6ab4a358529615"
+checksum = "f9a81d2759aae1dae668f783c308bc5c8ebd191ff4184aaa1b37f65a6ae5a56f"
 dependencies = [
  "plotters-backend",
 ]
@@ -1122,50 +1200,26 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.43"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rand"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
-dependencies = [
- "autocfg 0.1.8",
- "libc",
- "rand_chacha 0.1.1",
- "rand_core 0.4.2",
- "rand_hc 0.1.0",
- "rand_isaac",
- "rand_jitter",
- "rand_pcg",
- "rand_xorshift",
- "winapi",
 ]
 
 [[package]]
@@ -1176,19 +1230,18 @@ checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
  "getrandom 0.1.16",
  "libc",
- "rand_chacha 0.2.1",
+ "rand_chacha",
  "rand_core 0.5.1",
- "rand_hc 0.2.0",
+ "rand_hc",
 ]
 
 [[package]]
-name = "rand_chacha"
-version = "0.1.1"
+name = "rand"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "556d3a1ca6600bfcbab7c7c91ccb085ac7fbbcd70e008a98742e7847f4f7bcef"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "autocfg 0.1.8",
- "rand_core 0.3.1",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1203,21 +1256,6 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
-
-[[package]]
-name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
@@ -1227,20 +1265,11 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.7",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b40677c7be09ae76218dc623efbf7b18e34bced3f38883af07bb75630a21bc4"
-dependencies = [
- "rand_core 0.3.1",
+ "getrandom 0.2.8",
 ]
 
 [[package]]
@@ -1253,61 +1282,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_isaac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ded997c9d5f13925be2a6fd7e66bf1872597f759fd9dd93513dd7e92e5a5ee08"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
-name = "rand_jitter"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
-dependencies = [
- "libc",
- "rand_core 0.4.2",
- "winapi",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abf9b09b01790cfe0364f52bf32995ea3c39f4d2dd011eac241d2914146d0b44"
-dependencies = [
- "autocfg 0.1.8",
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_xorshift"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
-dependencies = [
- "rand_core 0.3.1",
-]
-
-[[package]]
 name = "rayon"
-version = "1.5.3"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+checksum = "6db3a213adf02b3bcfd2d3846bb41cb22857d131789e01df434fb7e7bc0759b7"
 dependencies = [
- "autocfg 1.1.0",
- "crossbeam-deque",
  "either",
  "rayon-core",
 ]
 
 [[package]]
 name = "rayon-core"
-version = "1.9.3"
+version = "1.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+checksum = "356a0625f1954f730c0201cdab48611198dc6ce21f4acff55089b5a78e6e835b"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
@@ -1317,9 +1305,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.6.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1327,16 +1315,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-automata"
-version = "0.1.10"
+name = "regex-syntax"
+version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
-name = "regex-syntax"
-version = "0.6.27"
+name = "rfc6979"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
+checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+dependencies = [
+ "crypto-bigint",
+ "hmac",
+ "zeroize",
+]
 
 [[package]]
 name = "rustc-demangle"
@@ -1354,10 +1347,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.11"
+name = "rustix"
+version = "0.36.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+checksum = "f43abb88211988493c1abb44a70efa56ff0ce98f233b7b276146f1f3f7ba9644"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
 
 [[package]]
 name = "same-file"
@@ -1375,45 +1382,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "secp256k1"
-version = "0.19.0"
+name = "sec1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6179428c22c73ac0fbb7b5579a56353ce78ba29759b3b8575183336ea74cdfb"
+checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
 dependencies = [
- "rand 0.6.5",
+ "base16ct",
+ "der",
+ "generic-array 0.14.6",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4124a35fe33ae14259c490fd70fa199a32b9ce9502f2ee6bc4f81ec06fa65894"
+dependencies = [
+ "rand 0.8.5",
  "secp256k1-sys",
  "serde",
 ]
 
 [[package]]
 name = "secp256k1-sys"
-version = "0.3.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11553d210db090930f4432bea123b31f70bbf693ace14504ea2a35e796c28dd2"
+checksum = "642a62736682fdd8c71da0eb273e453c8ac74e33b9fb310e22ba5b03ec7651ff"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "semver"
-version = "1.0.13"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
+checksum = "58bc9567378fc7690d6b2addae4e60ac2eeea07becb2c64b9f218b53865cba2a"
 
 [[package]]
 name = "serde"
-version = "1.0.142"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e590c437916fb6b221e1d00df6e3294f3fccd70ca7e92541c475d6ed6ef5fee2"
+checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.7"
+version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfc50e8183eeeb6178dcb167ae34a8051d63535023ae38b5d8d12beae193d37b"
+checksum = "416bda436f9aab92e02c8e10d49a15ddd339cea90b6e340fe51ed97abb548294"
 dependencies = [
  "serde",
 ]
@@ -1430,9 +1451,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.142"
+version = "1.0.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34b5b8d809babe02f538c2cfec6f2c1ed10804c0e5a6a041a049a4f5588ccc2e"
+checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1441,11 +1462,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.83"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
+checksum = "cad406b69c91885b5107daf2c29572f6c8cdb3c66826821e286c533490c0bc76"
 dependencies = [
- "itoa 1.0.3",
+ "itoa",
  "ryu",
  "serde",
 ]
@@ -1461,6 +1482,17 @@ dependencies = [
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.6",
  "sha2-asm",
 ]
 
@@ -1488,14 +1520,12 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.9.1"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81199417d4e5de3f04b1e871023acea7389672c4135918f05aa9cbf2f2fa809"
+checksum = "bdf0c33fae925bdc080598b84bc15c55e7b9a4a43b3c704da051f977469691c9"
 dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
+ "digest 0.10.6",
  "keccak",
- "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -1503,17 +1533,24 @@ name = "signature"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2807892cfa58e081aa1f1111391c7a0649d4fa127a4ffbe34bcbfb35a1171a4"
+
+[[package]]
+name = "signature"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fe458c98333f9c8152221191a77e2a44e8325d0193484af2e9421a53019e57d"
 dependencies = [
- "digest 0.9.0",
- "rand_core 0.6.3",
+ "digest 0.10.6",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "spki"
-version = "0.4.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c01a0c15da1b0b0e1494112e7af814a678fec9bd157881b49beac661e9b6f32"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
 dependencies = [
+ "base64ct",
  "der",
 ]
 
@@ -1534,9 +1571,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.99"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1557,9 +1594,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
 ]
@@ -1585,27 +1622,27 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
+checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.3"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
+checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
 
 [[package]]
 name = "universal-hash"
@@ -1629,7 +1666,7 @@ dependencies = [
  "arrayref",
  "blake2",
  "block-modes",
- "block-padding 0.2.1",
+ "block-padding 0.3.2",
  "bytebuffer-rs",
  "chacha20poly1305",
  "clear_on_drop",
@@ -1655,12 +1692,12 @@ dependencies = [
  "num-traits",
  "openssl",
  "rand 0.7.3",
- "rand_chacha 0.2.1",
+ "rand_chacha",
  "secp256k1",
  "serde",
  "serde_json",
- "sha2",
- "sha3 0.9.1",
+ "sha2 0.10.6",
+ "sha3 0.10.6",
  "subtle",
  "wasm-bindgen",
  "x25519-dalek",
@@ -1704,9 +1741,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.82"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
+checksum = "31f8dcbc21f30d9b8f2ea926ecb58f6b91192c17e9d33594b3df58b2007ca53b"
 dependencies = [
  "cfg-if",
  "serde",
@@ -1716,9 +1753,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.82"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
+checksum = "95ce90fd5bcc06af55a641a86428ee4229e44e07033963a2290a8e241607ccb9"
 dependencies = [
  "bumpalo",
  "log",
@@ -1731,9 +1768,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.82"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
+checksum = "4c21f77c0bedc37fd5dc21f897894a5ca01e7bb159884559461862ae90c0b4c5"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1741,9 +1778,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.82"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
+checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1754,15 +1791,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.82"
+version = "0.2.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
+checksum = "0046fef7e28c3804e5e38bfa31ea2a0f73905319b677e57ebe37e49358989b5d"
 
 [[package]]
 name = "web-sys"
-version = "0.3.59"
+version = "0.3.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed055ab27f941423197eb86b2035720b1a3ce40504df082cac2ecc6ed73335a1"
+checksum = "e33b99f4b23ba3eec1a53ac264e35a755f00e966e0065077d6027c0f575b0b97"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1800,10 +1837,75 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "x25519-dalek"
-version = "1.2.0"
+name = "windows-sys"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2392b6b94a576b4e2bf3c5b2757d63f10ada8020a2e4d08ac849ebcf6ea8e077"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
+
+[[package]]
+name = "x25519-dalek"
+version = "1.2.1"
+source = "git+https://github.com/appetrosyan/x25519-dalek#f92133acbe534bebe5f2983e251cb99a00fb57ce"
 dependencies = [
  "curve25519-dalek",
  "rand_core 0.5.1",
@@ -1812,18 +1914,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.3.0"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4756f7db3f7b5574938c3eb1c117038b8e07f95ee6718c0efad4ac21508f1efd"
+checksum = "c394b5bd0c6f669e7275d9c20aa90ae064cb22e75a1cad54e1b34088034b149f"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.3.2"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8f187641dad4f680d25c4bfc4225b418165984179f26ca76ec4fb6441d3a17"
+checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/libursa/Cargo.toml
+++ b/libursa/Cargo.toml
@@ -113,51 +113,51 @@ aes = { version = "0.6", optional = true }
 aes-gcm = { version = "0.8", optional = true }
 amcl = { version = "0.2",  optional = true, default-features = false, features = ["bn254"]}
 amcl_wrapper = {version = "0.4.0", features = ["bls381"], optional = true }
-arrayref = { version = "0.3.5", optional = true }
-blake2 = { version = "0.9", default-features = false, optional = true }
+arrayref = { version = "0.3.6", optional = true }
+blake2 = { version = "0.10", default-features = false, optional = true }
 block-modes = { version = "0.7", optional = true }
-block-padding = { version = "0.2", optional = true }
-clear_on_drop = { version = "0.2.4", optional = true }
-console_error_panic_hook = { version = "0.1.5", optional = true }
-curve25519-dalek = { version = "3.1", default-features = false, optional = true }
+block-padding = { version = "0.3", optional = true }
+clear_on_drop = { version = "0.2.5", optional = true }
+console_error_panic_hook = { version = "0.1.7", optional = true }
+curve25519-dalek = { version = "3.2", default-features = false, optional = true }
 ed25519-dalek = { version = "1.0", default-features = false, optional = true }
-env_logger = { version = "0.7.0", optional = true }
-failure = { version = "0.1.6", optional = true }
+env_logger = { version = "0.10", optional = true }
+failure = { version = "0.1.8", optional = true }
 ffi-support = { version = "0.4", optional = true }
-glass_pumpkin = { version = "0.4", optional = true }
-hex = { version = "0.4.0", optional = true }
-hkdf = { version = "0.11.0", optional = true }
-hmac = { version = "0.11.0", optional = true }
+glass_pumpkin = { version = "1.5", optional = true }
+hex = { version = "0.4.3", optional = true }
+hkdf = { version = "0.12", optional = true }
+hmac = { version = "0.12.1", optional = true }
 int_traits = { version = "0.1.1", optional = true }
-js-sys = { version = "0.3.13", optional = true }
+js-sys = { version = "0.3.61", optional = true }
 lazy_static = { version = "1.4", optional = true }
-log = { version = "0.4.8", optional = true }
-num-bigint = { version = "0.3.0", features = ["rand"], optional = true}
-num-integer = { version = "=0.1.42", optional = true }
-num-traits = { version = "=0.2.11", optional = true }
+log = { version = "0.4.17", optional = true }
+num-bigint = { version = "0.4", features = ["rand"], optional = true }
+num-integer = { version = "0.1.45", optional = true }
+num-traits = { version = "0.2.15", optional = true }
 openssl = { version = "0.10", optional = true }
 # TODO: Find out if the wasm-bindgen feature can be made dependent on our own wasm feature
 rand = { version = "0.7", features = ["wasm-bindgen"], optional = true }
 getrandom = { version = "0.2", features = ["js"], optional = true }
 rand_chacha = { version = "=0.2.1", optional = true }
 rustchacha20poly1305 = { version = "0.7", package = "chacha20poly1305", optional = true }
-k256 = { version = "0.9.6", optional = true, features = ["ecdh", "ecdsa", "sha256"]}
-bitcoinsecp256k1 = { version = "0.19", package = "secp256k1", optional = true, features = ["rand", "serde"]}
-serde = { version = "1.0", features = ["derive"],  optional = true}
+k256 = { version = "0.12", optional = true, features = ["ecdh", "ecdsa", "sha256"]}
+bitcoinsecp256k1 = { version = "0.26", package = "secp256k1", optional = true, features = ["rand", "serde"]}
+serde = { version = "1.0", features = ["derive"],  optional = true }
 serde_json = { version = "1.0", optional = true }
-sha2 = { version = "0.9.5", default-features = false, optional = true }
-sha3 = { version = "0.9.1", optional = true }
-subtle = { version = "2.3", optional = true }
+sha2 = { version = "0.10", default-features = false, optional = true }
+sha3 = { version = "0.10", optional = true }
+subtle = { version = "2.4", optional = true }
 wasm-bindgen = { version = "0.2", optional = true, features = ["serde-serialize"] }
-x25519-dalek = { version = "1.1", optional = true, default-features = false }
-zeroize = { version = "1.1", features = ["zeroize_derive"], optional =  true }
+x25519-dalek = { version = "1.2.1", optional = true, default-features = false, git = "https://github.com/appetrosyan/x25519-dalek" }
+zeroize = { version = "1.5", features = ["zeroize_derive"], optional =  true }
 
 [dev-dependencies]
-bytebuffer-rs = "0.3.0"
+bytebuffer-rs = "2.0.1"
 criterion = "0.3"
 openssl = "0.10"
-k256 = { version = "0.9.6"}
-bitcoinsecp256k1 = { version = "0.19", package = "secp256k1"}
+k256 = { version = "0.12"}
+bitcoinsecp256k1 = { version = "0.26", package = "secp256k1"}
 serde_json = "1.0"
 
 [[bench]]

--- a/libursa/Cargo.toml
+++ b/libursa/Cargo.toml
@@ -2,12 +2,13 @@
 name = "ursa"
 version = "0.3.7"
 authors = ["Hyperledger Ursa Contributors"]
-description = "This is the shared crypto library for Hyperledger components."
+description = "The Hyperledger Cryptographic library."
 license = "Apache-2.0"
 readme =  "../README.md"
 repository = "https://github.com/hyperledger/ursa"
 documentation = "https://docs.rs/ursa"
 homepage = "https://crates.io/crates/ursa"
+edition = "2021"
 keywords = ["cryptography", "aead", "hash", "signature", "zero-knowledge"]
 include = [
     "src/bls/**/*.rs",
@@ -177,7 +178,7 @@ license-file = ["../LICENSE", "0"]
 copyright = "2019, Hyperledger"
 depends = "$auto"
 extended-description = """\
-Rust written reliable, secure, easy-to-use, and pluggable cryptographic implementations."""
+Rust-written reliable, secure, easy-to-use, and pluggable cryptographic implementations."""
 section = "admin"
 revision = "1"
 priority = "optional"

--- a/libursa/src/bls/mod.rs
+++ b/libursa/src/bls/mod.rs
@@ -1,5 +1,5 @@
-use errors::prelude::*;
-use pair::{GroupOrderElement, Pair, PointG1, PointG2};
+use crate::errors::prelude::*;
+use crate::pair::{GroupOrderElement, Pair, PointG1, PointG2};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};

--- a/libursa/src/bn/openssl.rs
+++ b/libursa/src/bn/openssl.rs
@@ -1,4 +1,4 @@
-use errors::prelude::*;
+use crate::errors::prelude::*;
 
 use int_traits::IntTraits;
 

--- a/libursa/src/cl/constants.rs
+++ b/libursa/src/cl/constants.rs
@@ -1,4 +1,4 @@
-use bn::{BigNumber, BIGNUMBER_2};
+use crate::bn::{BigNumber, BIGNUMBER_2};
 
 pub const LARGE_MASTER_SECRET: usize = 256;
 pub const LARGE_E_START: usize = 596;

--- a/libursa/src/cl/hash.rs
+++ b/libursa/src/cl/hash.rs
@@ -1,5 +1,5 @@
-use bn::BigNumber;
-use errors::prelude::*;
+use crate::bn::BigNumber;
+use crate::errors::prelude::*;
 
 pub fn get_hash_as_int(nums: &[Vec<u8>]) -> UrsaCryptoResult<BigNumber> {
     trace!("Helpers::get_hash_as_int: >>> nums: {:?}", nums);

--- a/libursa/src/cl/helpers.rs
+++ b/libursa/src/cl/helpers.rs
@@ -1,8 +1,8 @@
 use super::constants::*;
-use bn::{BigNumber, BIGNUMBER_1};
-use cl::*;
-use errors::prelude::*;
-use pair::GroupOrderElement;
+use crate::bn::{BigNumber, BIGNUMBER_1};
+use crate::cl::*;
+use crate::errors::prelude::*;
+use crate::pair::GroupOrderElement;
 
 use std::cmp::max;
 use std::collections::{HashMap, HashSet};
@@ -669,7 +669,7 @@ pub fn create_tau_list_values(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cl::{issuer, prover};
+    use crate::cl::{issuer, prover};
 
     #[test]
     fn encode_attribute_works() {

--- a/libursa/src/cl/issuer.rs
+++ b/libursa/src/cl/issuer.rs
@@ -1,11 +1,11 @@
-use bn::BigNumber;
-use cl::constants::*;
-use cl::hash::get_hash_as_int;
-use cl::helpers::*;
-use cl::*;
-use errors::prelude::*;
-use pair::*;
-use utils::commitment::get_pedersen_commitment;
+use crate::bn::BigNumber;
+use crate::cl::constants::*;
+use crate::cl::hash::get_hash_as_int;
+use crate::cl::helpers::*;
+use crate::cl::*;
+use crate::errors::prelude::*;
+use crate::pair::*;
+use crate::utils::commitment::get_pedersen_commitment;
 
 use std::collections::{BTreeSet, HashMap, HashSet};
 use std::iter::FromIterator;
@@ -1416,8 +1416,8 @@ mod tests {
     use self::prover::mocks as prover_mocks;
     use self::prover::Prover;
     use super::*;
-    use cl::helpers::MockHelper;
-    use cl::issuer::{mocks, Issuer};
+    use crate::cl::helpers::MockHelper;
+    use crate::cl::issuer::{mocks, Issuer};
 
     #[test]
     fn generate_context_attribute_works() {

--- a/libursa/src/cl/mod.rs
+++ b/libursa/src/cl/mod.rs
@@ -9,9 +9,9 @@ pub mod issuer;
 pub mod prover;
 pub mod verifier;
 
-use bn::BigNumber;
-use errors::prelude::*;
-use pair::*;
+use crate::bn::BigNumber;
+use crate::errors::prelude::*;
+use crate::pair::*;
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};

--- a/libursa/src/cl/prover.rs
+++ b/libursa/src/cl/prover.rs
@@ -1,11 +1,11 @@
 use super::helpers::*;
-use bn::BigNumber;
-use cl::constants::*;
-use cl::hash::get_hash_as_int;
-use cl::*;
-use errors::prelude::*;
-use pair::*;
-use utils::commitment::get_pedersen_commitment;
+use crate::bn::BigNumber;
+use crate::cl::constants::*;
+use crate::cl::hash::get_hash_as_int;
+use crate::cl::*;
+use crate::errors::prelude::*;
+use crate::pair::*;
+use crate::utils::commitment::get_pedersen_commitment;
 
 use std::collections::{BTreeMap, BTreeSet, HashSet};
 
@@ -1902,7 +1902,7 @@ impl ProofBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cl::issuer;
+    use crate::cl::issuer;
     #[cfg(feature = "serde")]
     use serde_json::{self, json};
     use std::time::Instant;

--- a/libursa/src/cl/verifier.rs
+++ b/libursa/src/cl/verifier.rs
@@ -1,9 +1,9 @@
-use bn::BigNumber;
-use cl::constants::{ITERATION, LARGE_E_START_VALUE};
-use cl::hash::get_hash_as_int;
-use cl::helpers::*;
-use cl::*;
-use errors::prelude::*;
+use crate::bn::BigNumber;
+use crate::cl::constants::{ITERATION, LARGE_E_START_VALUE};
+use crate::cl::hash::get_hash_as_int;
+use crate::cl::helpers::*;
+use crate::cl::*;
+use crate::errors::prelude::*;
 
 use std::collections::hash_map::Entry;
 use std::collections::{BTreeSet, HashMap};
@@ -644,10 +644,10 @@ impl ProofVerifier {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cl::helpers::MockHelper;
-    use cl::issuer;
-    use cl::prover;
-    use cl::prover::mocks::*;
+    use crate::cl::helpers::MockHelper;
+    use crate::cl::issuer;
+    use crate::cl::prover;
+    use crate::cl::prover::mocks::*;
 
     #[test]
     fn sub_proof_request_builder_works() {

--- a/libursa/src/encryption/symm/aescbc.rs
+++ b/libursa/src/encryption/symm/aescbc.rs
@@ -9,7 +9,7 @@ use aead::{
 use aes::{Aes128, Aes256};
 use block_modes::block_padding::Pkcs7;
 use block_modes::{BlockMode, Cbc};
-use hmac::{Hmac, Mac, NewMac};
+use hmac::{Hmac, Mac};
 #[cfg(feature = "serde")]
 use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
 use sha2::{Sha256, Sha512};

--- a/libursa/src/errors/mod.rs
+++ b/libursa/src/errors/mod.rs
@@ -1,7 +1,7 @@
 extern crate log;
 
 #[cfg(feature = "ffi")]
-use ffi::ErrorCode;
+use crate::ffi::ErrorCode;
 
 use std::cell::RefCell;
 use std::ffi::CString;
@@ -14,7 +14,7 @@ use std::ptr;
 use failure::{Backtrace, Context, Fail};
 
 #[cfg(feature = "ffi")]
-use utils::ctypes;
+use crate::utils::ctypes;
 
 #[cfg(feature = "ffi")]
 pub mod prelude {

--- a/libursa/src/ffi/bls.rs
+++ b/libursa/src/ffi/bls.rs
@@ -1,7 +1,7 @@
-use bls::*;
-use errors::prelude::*;
+use crate::bls::*;
+use crate::errors::prelude::*;
 
-use ffi::ErrorCode;
+use crate::ffi::ErrorCode;
 use std::os::raw::c_void;
 use std::slice;
 

--- a/libursa/src/ffi/bls.rs
+++ b/libursa/src/ffi/bls.rs
@@ -132,7 +132,7 @@ pub extern "C" fn ursa_bls_generator_free(gen: *const c_void) -> ErrorCode {
     check_useful_c_ptr!(gen, ErrorCode::CommonInvalidParam1);
 
     unsafe {
-        Box::from_raw(gen as *mut Generator);
+        drop(Box::from_raw(gen as *mut Generator));
     }
     let res = ErrorCode::Success;
 
@@ -294,7 +294,7 @@ pub extern "C" fn ursa_bls_sign_key_free(sign_key: *const c_void) -> ErrorCode {
     );
 
     unsafe {
-        Box::from_raw(sign_key as *mut SignKey);
+        drop(Box::from_raw(sign_key as *mut SignKey));
     }
     let res = ErrorCode::Success;
 
@@ -444,7 +444,7 @@ pub extern "C" fn ursa_bls_ver_key_free(ver_key: *const c_void) -> ErrorCode {
     trace!("ursa_bls_ver_key_free: >>> ver_key: {:?}", ver_key);
 
     unsafe {
-        Box::from_raw(ver_key as *mut VerKey);
+        drop(Box::from_raw(ver_key as *mut VerKey));
     }
     let res = ErrorCode::Success;
 
@@ -594,7 +594,7 @@ pub extern "C" fn ursa_bls_pop_free(pop: *const c_void) -> ErrorCode {
     trace!("ursa_bls_pop_free: >>> pop: {:?}", pop);
 
     unsafe {
-        Box::from_raw(pop as *mut ProofOfPossession);
+        drop(Box::from_raw(pop as *mut ProofOfPossession));
     }
     let res = ErrorCode::Success;
 
@@ -701,7 +701,7 @@ pub extern "C" fn ursa_bls_signature_free(signature: *const c_void) -> ErrorCode
     trace!("ursa_bls_signature_free: >>> signature: {:?}", signature);
 
     unsafe {
-        Box::from_raw(signature as *mut Signature);
+        drop(Box::from_raw(signature as *mut Signature));
     }
     let res = ErrorCode::Success;
 
@@ -864,7 +864,7 @@ pub extern "C" fn ursa_bls_multi_signature_free(multi_sig: *const c_void) -> Err
     );
 
     unsafe {
-        Box::from_raw(multi_sig as *mut MultiSignature);
+        drop(Box::from_raw(multi_sig as *mut MultiSignature));
     }
     let res = ErrorCode::Success;
 

--- a/libursa/src/ffi/cl/issuer.rs
+++ b/libursa/src/ffi/cl/issuer.rs
@@ -1,9 +1,9 @@
-use cl::issuer::*;
-use cl::*;
-use errors::prelude::*;
-use ffi::cl::{FFITailPut, FFITailTake, FFITailsAccessor};
-use ffi::ErrorCode;
-use utils::ctypes::*;
+use crate::cl::issuer::*;
+use crate::cl::*;
+use crate::errors::prelude::*;
+use crate::ffi::cl::{FFITailPut, FFITailTake, FFITailsAccessor};
+use crate::ffi::ErrorCode;
+use crate::utils::ctypes::*;
 
 use serde_json;
 use std::collections::HashSet;
@@ -2012,9 +2012,9 @@ pub extern "C" fn ursa_cl_issuer_merge_revocation_registry_deltas(
 mod tests {
     use super::*;
 
-    use ffi::cl::issuer::mocks::*;
-    use ffi::cl::mocks::*;
-    use ffi::cl::prover::mocks::*;
+    use crate::ffi::cl::issuer::mocks::*;
+    use crate::ffi::cl::mocks::*;
+    use crate::ffi::cl::prover::mocks::*;
     use std::ptr;
 
     #[test]
@@ -3025,7 +3025,7 @@ mod tests {
 pub mod mocks {
     use super::*;
 
-    use ffi::cl::mocks::*;
+    use crate::ffi::cl::mocks::*;
     use std::ffi::CString;
     use std::ptr;
 

--- a/libursa/src/ffi/cl/mod.rs
+++ b/libursa/src/ffi/cl/mod.rs
@@ -1,9 +1,9 @@
-use cl::issuer::Issuer;
-use cl::verifier::Verifier;
-use cl::*;
-use errors::prelude::*;
-use ffi::ErrorCode;
-use utils::ctypes::*;
+use crate::cl::issuer::Issuer;
+use crate::cl::verifier::Verifier;
+use crate::cl::*;
+use crate::errors::prelude::*;
+use crate::ffi::ErrorCode;
+use crate::utils::ctypes::*;
 
 use serde_json;
 use std::os::raw::{c_char, c_void};
@@ -1221,7 +1221,7 @@ impl RevocationTailsAccessor for FFITailsAccessor {
 mod tests {
     use super::*;
 
-    use ffi::cl::mocks::*;
+    use crate::ffi::cl::mocks::*;
     use std::ffi::CString;
     use std::ptr;
 

--- a/libursa/src/ffi/cl/prover.rs
+++ b/libursa/src/ffi/cl/prover.rs
@@ -1,8 +1,8 @@
-use cl::prover::*;
-use cl::*;
-use errors::prelude::*;
-use ffi::ErrorCode;
-use utils::ctypes::*;
+use crate::cl::prover::*;
+use crate::cl::*;
+use crate::errors::prelude::*;
+use crate::ffi::ErrorCode;
+use crate::utils::ctypes::*;
 
 use serde_json;
 use std::os::raw::{c_char, c_void};
@@ -1261,9 +1261,9 @@ pub extern "C" fn ursa_cl_proof_free(proof: *const c_void) -> ErrorCode {
 mod tests {
     use super::*;
 
-    use ffi::cl::issuer::mocks::*;
-    use ffi::cl::mocks::*;
-    use ffi::cl::prover::mocks::*;
+    use crate::ffi::cl::issuer::mocks::*;
+    use crate::ffi::cl::mocks::*;
+    use crate::ffi::cl::prover::mocks::*;
     use std::ptr;
 
     // Master secret is now called link secret.
@@ -2207,7 +2207,7 @@ mod tests {
 pub mod mocks {
     use super::*;
 
-    use ffi::cl::mocks::*;
+    use crate::ffi::cl::mocks::*;
     use std::ptr;
 
     pub fn _master_secret() -> *const c_void {

--- a/libursa/src/ffi/cl/verifier.rs
+++ b/libursa/src/ffi/cl/verifier.rs
@@ -1,8 +1,8 @@
-use cl::verifier::*;
-use cl::*;
-use errors::prelude::*;
-use ffi::ErrorCode;
-use utils::ctypes::*;
+use crate::cl::verifier::*;
+use crate::cl::*;
+use crate::errors::prelude::*;
+use crate::ffi::ErrorCode;
+use crate::utils::ctypes::*;
 
 use std::os::raw::{c_char, c_void};
 
@@ -208,7 +208,7 @@ mod tests {
     use super::super::issuer::mocks::*;
     use super::super::prover::mocks::*;
     use super::mocks::*;
-    use ffi::cl::mocks::*;
+    use crate::ffi::cl::mocks::*;
     use std::ptr;
 
     // Master secret is now called link secret.

--- a/libursa/src/ffi/encryption/mod.rs
+++ b/libursa/src/ffi/encryption/mod.rs
@@ -1,7 +1,7 @@
 use super::ByteArray;
+use crate::encryption::random_vec;
+use crate::encryption::symm::prelude::*;
 use aead::{generic_array::typenum::Unsigned, Aead, NewAead};
-use encryption::random_vec;
-use encryption::symm::prelude::*;
 use ffi_support::{ByteBuffer, ErrorCode, ExternError, FfiStr};
 use std::ffi::CString;
 use std::str::FromStr;

--- a/libursa/src/ffi/logger.rs
+++ b/libursa/src/ffi/logger.rs
@@ -1,12 +1,12 @@
 use std::os::raw::{c_char, c_void};
 
-use errors::prelude::*;
-use ffi::ErrorCode;
+use crate::errors::prelude::*;
+use crate::ffi::ErrorCode;
 
 extern crate log;
 
-use utils::ctypes::*;
-use utils::logger::{EnabledCB, FlushCB, HLCryptoDefaultLogger, HLCryptoLogger, LogCB};
+use crate::utils::ctypes::*;
+use crate::utils::logger::{EnabledCB, FlushCB, HLCryptoDefaultLogger, HLCryptoLogger, LogCB};
 
 /// Set custom logger implementation.
 ///

--- a/libursa/src/ffi/mod.rs
+++ b/libursa/src/ffi/mod.rs
@@ -12,7 +12,7 @@ pub mod logger;
 ))]
 pub mod signatures;
 
-use errors::prelude::*;
+use crate::errors::prelude::*;
 use ffi_support::ByteBuffer;
 use std::os::raw::c_char;
 
@@ -192,9 +192,9 @@ pub extern "C" fn ursa_get_current_error(error_json_p: *mut *const c_char) {
 mod tests {
     use super::*;
 
-    use ffi::cl::issuer::ursa_cl_credential_private_key_from_json;
+    use crate::ffi::cl::issuer::ursa_cl_credential_private_key_from_json;
+    use crate::utils::ctypes::*;
     use std::ptr;
-    use utils::ctypes::*;
 
     #[test]
     fn ursa_get_current_error_works() {

--- a/libursa/src/ffi/signatures/ed25519.rs
+++ b/libursa/src/ffi/signatures/ed25519.rs
@@ -146,9 +146,9 @@
 // }
 
 use super::super::ByteArray;
-use keys::{KeyGenOption, PrivateKey, PublicKey};
-use signatures::ed25519;
-use signatures::prelude::*;
+use crate::keys::{KeyGenOption, PrivateKey, PublicKey};
+use crate::signatures::ed25519;
+use crate::signatures::prelude::*;
 
 use ffi_support::{ByteBuffer, ErrorCode, ExternError};
 

--- a/libursa/src/hash/blake2.rs
+++ b/libursa/src/hash/blake2.rs
@@ -1,4 +1,4 @@
 #[cfg(target_pointer_width = "64")]
-pub use crate::blake2::{Blake2b as Blake2, VarBlake2b as VarBlake2};
+pub use crate::blake2::Blake2b as Blake2;
 #[cfg(target_pointer_width = "32")]
-pub use crate::blake2::{Blake2s as Blake2, VarBlake2s as VarBlake2};
+pub use crate::blake2::Blake2s as Blake2;

--- a/libursa/src/kex/mod.rs
+++ b/libursa/src/kex/mod.rs
@@ -1,7 +1,7 @@
 //! A suite of Diffie-Hellman key exchange methods.
 
-use keys::{KeyGenOption, PrivateKey, PublicKey, SessionKey};
-use CryptoError;
+use crate::keys::{KeyGenOption, PrivateKey, PublicKey, SessionKey};
+use crate::CryptoError;
 
 /// A Generic trait for key exchange schemes. Each scheme provides a way to generate keys and
 /// do a diffie-hellman computation

--- a/libursa/src/kex/secp256k1.rs
+++ b/libursa/src/kex/secp256k1.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-use CryptoError;
+use crate::CryptoError;
 
 pub const PRIVATE_KEY_SIZE: usize = 32;
 pub const PUBLIC_KEY_SIZE: usize = 33;

--- a/libursa/src/kex/x25519.rs
+++ b/libursa/src/kex/x25519.rs
@@ -6,7 +6,7 @@ use sha2::Digest;
 use x25519_dalek::{PublicKey as X25519PublicKey, StaticSecret};
 use zeroize::Zeroize;
 
-use CryptoError;
+use crate::CryptoError;
 
 pub struct X25519Sha256;
 
@@ -78,7 +78,7 @@ mod tests {
     #[cfg(any(feature = "ed25519", feature = "ed25519_asm"))]
     #[test]
     fn convert_from_sig_keys() {
-        use signatures::{ed25519::Ed25519Sha512, SignatureScheme};
+        use crate::signatures::{ed25519::Ed25519Sha512, SignatureScheme};
         let sig_scheme = Ed25519Sha512::new();
         let (pk, sk) = sig_scheme.keypair(None).unwrap();
         let res = Ed25519Sha512::ver_key_to_key_exchange(&pk);

--- a/libursa/src/lib.rs
+++ b/libursa/src/lib.rs
@@ -249,32 +249,23 @@ impl std::fmt::Display for CryptoError {
 #[cfg(feature = "bitcoinsecp256k1")]
 impl From<bitcoinsecp256k1::Error> for CryptoError {
     fn from(error: bitcoinsecp256k1::Error) -> CryptoError {
-        match error {
-            bitcoinsecp256k1::Error::IncorrectSignature => {
-                CryptoError::ParseError("Incorrect Signature".to_string())
+        use bitcoinsecp256k1::Error::*;
+        CryptoError::ParseError(
+            match error {
+                IncorrectSignature => "Incorrect signature",
+                InvalidMessage => "Invalid message",
+                InvalidPublicKey => "Invalid public key",
+                InvalidPublicKeySum => "Invalid public key sum",
+                InvalidSignature => "Invalid signature",
+                InvalidSharedSecret => "Invalid shared secret",
+                InvalidSecretKey => "Invalid secret key",
+                InvalidRecoveryId => "Invalid recovery id",
+                InvalidTweak => "Invalid tweak",
+                NotEnoughMemory => "Not enough memory",
+                InvalidParityValue(_) => "Invalid parity", // Value is opaque, cannot print
             }
-            bitcoinsecp256k1::Error::InvalidMessage => {
-                CryptoError::ParseError("Invalid Message".to_string())
-            }
-            bitcoinsecp256k1::Error::InvalidPublicKey => {
-                CryptoError::ParseError("Invalid Public Key".to_string())
-            }
-            bitcoinsecp256k1::Error::InvalidSignature => {
-                CryptoError::ParseError("Invalid Signature".to_string())
-            }
-            bitcoinsecp256k1::Error::InvalidSecretKey => {
-                CryptoError::ParseError("Invalid Secret Key".to_string())
-            }
-            bitcoinsecp256k1::Error::InvalidRecoveryId => {
-                CryptoError::ParseError("Invalid Recovery Id".to_string())
-            }
-            bitcoinsecp256k1::Error::InvalidTweak => {
-                CryptoError::ParseError("Invalid Tweak".to_string())
-            }
-            bitcoinsecp256k1::Error::NotEnoughMemory => {
-                CryptoError::ParseError("Not Enough Memory".to_string())
-            }
-        }
+            .to_owned(),
+        )
     }
 }
 
@@ -292,7 +283,6 @@ impl From<bitcoinsecp256k1::Error> for CryptoError {
 ))]
 impl From<errors::UrsaCryptoError> for CryptoError {
     fn from(err: errors::UrsaCryptoError) -> Self {
-        let kind = err.kind();
-        CryptoError::GeneralError(format!("{}", kind))
+        CryptoError::GeneralError(format!("{}", err.kind()))
     }
 }

--- a/libursa/src/pair/amcl.rs
+++ b/libursa/src/pair/amcl.rs
@@ -1,4 +1,4 @@
-use errors::prelude::*;
+use crate::errors::prelude::*;
 
 use amcl::bn254::big::BIG;
 

--- a/libursa/src/sharing/shamir.rs
+++ b/libursa/src/sharing/shamir.rs
@@ -9,10 +9,10 @@
 //! Future work would be to use pedersen commitments or reed-solomon
 //! codes to check for corrupted shares.
 
-use bn::BigNumber;
+use crate::bn::BigNumber;
 use std::{cmp::Ordering, collections::BTreeSet};
 
-use {CryptoError, CryptoResult};
+use crate::{CryptoError, CryptoResult};
 
 /// Represents an element in a finite field as [0, n)
 #[derive(Debug)]

--- a/libursa/src/signatures/bls.rs
+++ b/libursa/src/signatures/bls.rs
@@ -1,4 +1,5 @@
 use super::SignatureScheme;
+use crate::keys::{KeyGenOption, PrivateKey as UrsaPrivateKey, PublicKey as UrsaPublicKey};
 /// Implements
 /// https://eprint.iacr.org/2018/483 and
 /// https://crypto.stanford.edu/~dabo/pubs/papers/BLSmultisig.html
@@ -11,12 +12,11 @@ use amcl_wrapper::{
     group_elem_g2::G2,
     types_g2::GroupG2_SIZE,
 };
-use keys::{KeyGenOption, PrivateKey as UrsaPrivateKey, PublicKey as UrsaPublicKey};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 
-use CryptoError;
+use crate::CryptoError;
 
 pub const PRIVATE_KEY_SIZE: usize = MODBYTES;
 /// This is a simple alias so the consumer can just use PrivateKey::random() to generate a new one

--- a/libursa/src/signatures/ed25519.rs
+++ b/libursa/src/signatures/ed25519.rs
@@ -1,6 +1,7 @@
 pub const ALGORITHM_NAME: &str = "ED25519_SHA2_512";
 
 use super::{KeyGenOption, SignatureScheme};
+use crate::keys::{PrivateKey, PublicKey};
 #[cfg(any(feature = "x25519", feature = "x25519_asm"))]
 use ed25519_dalek::SecretKey as SK;
 use ed25519_dalek::{Keypair, PublicKey as PK, Signature, Signer, Verifier};
@@ -8,7 +9,6 @@ pub use ed25519_dalek::{
     EXPANDED_SECRET_KEY_LENGTH as PRIVATE_KEY_SIZE, PUBLIC_KEY_LENGTH as PUBLIC_KEY_SIZE,
     SIGNATURE_LENGTH as SIGNATURE_SIZE,
 };
-use keys::{PrivateKey, PublicKey};
 use rand::rngs::OsRng;
 use rand::SeedableRng;
 use rand_chacha::ChaChaRng;
@@ -16,7 +16,7 @@ use sha2::Digest;
 use std::convert::TryFrom;
 use zeroize::Zeroize;
 
-use CryptoError;
+use crate::CryptoError;
 
 pub struct Ed25519Sha512;
 
@@ -169,7 +169,7 @@ mod test {
     use self::Ed25519Sha512;
     use super::super::{SignatureScheme, Signer};
     use super::*;
-    use keys::{KeyGenOption, PrivateKey, PublicKey};
+    use crate::keys::{KeyGenOption, PrivateKey, PublicKey};
 
     const MESSAGE_1: &[u8] = b"This is a dummy message for use with tests";
     const SIGNATURE_1: &str = "451b5b8e8725321541954997781de51f4142e4a56bab68d24f6a6b92615de5eefb74134138315859a32c7cf5fe5a488bc545e2e08e5eedfd1fb10188d532d808";

--- a/libursa/src/signatures/mod.rs
+++ b/libursa/src/signatures/mod.rs
@@ -21,8 +21,8 @@ pub mod prelude {
     pub use super::{SignatureScheme, Signer};
 }
 
-use keys::{KeyGenOption, PrivateKey, PublicKey};
-use CryptoError;
+use crate::keys::{KeyGenOption, PrivateKey, PublicKey};
+use crate::CryptoError;
 
 pub trait SignatureScheme {
     fn new() -> Self;

--- a/libursa/src/signatures/secp256k1.rs
+++ b/libursa/src/signatures/secp256k1.rs
@@ -1,7 +1,6 @@
 use super::*;
 
 use sha2::digest::generic_array::typenum::U32;
-use CryptoError;
 
 #[cfg(feature = "serde")]
 use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};

--- a/libursa/src/utils/commitment.rs
+++ b/libursa/src/utils/commitment.rs
@@ -1,5 +1,5 @@
-use bn::{BigNumber, BigNumberContext};
-use errors::prelude::*;
+use crate::bn::{BigNumber, BigNumberContext};
+use crate::errors::prelude::*;
 
 /// Generate a pedersen commitment to a given number
 ///

--- a/libursa/src/utils/logger.rs
+++ b/libursa/src/utils/logger.rs
@@ -7,7 +7,7 @@ use log::{Metadata, Record};
 use std::env;
 use std::io::Write;
 
-use errors::prelude::*;
+use crate::errors::prelude::*;
 
 use std::ffi::CString;
 use std::os::raw::{c_char, c_void};


### PR DESCRIPTION
Simple version bump for all Rust edition 2015 idioms. 

# Description of change

- Applied `cargo fix --edition` 


# Issues

Closes #224 

# Testing

### Tests added 

No extra tests added

### Existing tests

Not altered

### Local test runs

Apple M2 - Pending

# Discussion

## Pros

- Able to link with newer libraries
- More idiomatic modern Rust

## Cons

- No longer backwards compatible 

# Special comments

Change of MSRV