### PR TITLE
make accum public

### DIFF
--- a/libursa/src/cl/mod.rs
+++ b/libursa/src/cl/mod.rs
@@ -424,7 +424,7 @@ pub type Accumulator = PointG2;
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub struct RevocationRegistry {
-    accum: Accumulator,
+    pub accum: Accumulator,
 }
 
 impl From<RevocationRegistryDelta> for RevocationRegistry {


### PR DESCRIPTION
This is required for anoncreds-rs as we use a different name for the key, [spec](https://hyperledger.github.io/anoncreds-spec/#creating-the-initial-revocation-status-list-object). Making it public makes sure we can just rename it easily, but this does not create a breaking change.