### PR TITLE
[feature]: remove `failure` and replace with `thiserror`

### DIFF
--- a/libursa/Cargo.lock
+++ b/libursa/Cargo.lock
@@ -3,21 +3,6 @@
 version = 3
 
 [[package]]
-name = "addr2line"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76fd60b23679b7d19bd066031410fb7e458ccc5e958eb5c325888ce4baedc97"
-dependencies = [
- "gimli",
-]
-
-[[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
 name = "aead"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -127,21 +112,6 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
-name = "backtrace"
-version = "0.3.67"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233d376d6d185f2a3093e58f283f60f880315b6c60075b01f36b3b85154564ca"
-dependencies = [
- "addr2line",
- "cc",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "object",
- "rustc-demangle",
-]
 
 [[package]]
 name = "base16ct"
@@ -670,28 +640,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
 name = "ff"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -780,12 +728,6 @@ dependencies = [
  "opaque-debug 0.3.0",
  "polyval",
 ]
-
-[[package]]
-name = "gimli"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0a93d233ebf96623465aad4046a8d3aa4da22d4f4beba5388838c8a434bbb4"
 
 [[package]]
 name = "glass_pumpkin"
@@ -996,15 +938,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "miniz_oxide"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
-dependencies = [
- "adler",
-]
-
-[[package]]
 name = "miracl_core"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1052,15 +985,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "object"
-version = "0.30.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea86265d3d3dcb6a27fc51bd29a4bf387fae9d2986b823079d4986af253eb439"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1086,9 +1010,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.45"
+version = "0.10.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
+checksum = "97ea2d98598bf9ada7ea6ee8a30fb74f9156b63bbe495d64ec2b87c269d2dda3"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1107,16 +1031,15 @@ checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.80"
+version = "0.9.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
+checksum = "992bac49bdbab4423199c654a5515bd2a6c6a23bf03f2dd3bdb7e5ae6259bc69"
 dependencies = [
- "autocfg",
  "cc",
  "libc",
  "pkg-config",
@@ -1206,18 +1129,18 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -1330,12 +1253,6 @@ dependencies = [
  "hmac",
  "zeroize",
 ]
-
-[[package]]
-name = "rustc-demangle"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustc_version"
@@ -1457,7 +1374,7 @@ checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1581,6 +1498,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "2.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1588,7 +1516,7 @@ checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "unicode-xid",
 ]
 
@@ -1608,6 +1536,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1675,9 +1623,8 @@ dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
  "env_logger",
- "failure",
  "ffi-support",
- "getrandom 0.2.7",
+ "getrandom 0.2.8",
  "glass_pumpkin",
  "hex",
  "hkdf",
@@ -1699,6 +1646,7 @@ dependencies = [
  "sha2 0.10.6",
  "sha3 0.10.6",
  "subtle",
+ "thiserror",
  "wasm-bindgen",
  "x25519-dalek",
  "zeroize",
@@ -1762,7 +1710,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "wasm-bindgen-shared",
 ]
 
@@ -1784,7 +1732,7 @@ checksum = "2aff81306fcac3c7515ad4e177f521b5c9a15f2b08f4e32d823066102f35a5f6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -1929,6 +1877,6 @@ checksum = "44bf07cb3e50ea2003396695d58bf46bc9887a1f362260446fad6bc4e79bd36c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "synstructure",
 ]

--- a/libursa/Cargo.toml
+++ b/libursa/Cargo.toml
@@ -73,23 +73,23 @@ benchmarked25519 = ["ed25519"]
 benchmarksecp256k1 = ["bitcoinsecp256k1", "openssl"]
 benchmarkxchacha20poly1305 = ["chacha20poly1305"]
 bls_bls12381 = ["amcl_wrapper", "hex", "hkdf", "sha2/std", "zeroize"]
-bls_bn254 = ["amcl", "failure", "log", "rand", "sha2/std", "sha3"]
-bls_bn254_asm = ["amcl", "failure", "log", "rand", "sha2/asm", "sha3"]
-cl = ["amcl", "failure", "glass_pumpkin", "int_traits", "lazy_static", "log", "num-bigint", "num-integer", "num-traits", "rand", "sha2/std"]
-cl_native = ["amcl", "failure", "int_traits", "lazy_static", "log", "openssl", "rand"]
+bls_bn254 = ["amcl", "log", "rand", "sha2/std", "sha3"]
+bls_bn254_asm = ["amcl", "log", "rand", "sha2/asm", "sha3"]
+cl = ["amcl", "glass_pumpkin", "int_traits", "lazy_static", "log", "num-bigint", "num-integer", "num-traits", "rand", "sha2/std"]
+cl_native = ["amcl", "int_traits", "lazy_static", "log", "openssl", "rand"]
 chacha20poly1305 = ["aead", "hex", "rand", "rustchacha20poly1305", "zeroize"]
 chacha20poly1305_native = ["chacha20poly1305"]
-ecdh_secp256k1 = ["amcl", "arrayref", "failure", "hex", "rand", "rand_chacha", "k256", "sha2/std", "zeroize"]
-ecdh_secp256k1_native = ["arrayref", "failure", "hex", "log", "rand", "bitcoinsecp256k1", "rand_chacha", "sha2/std", "zeroize"]
-ecdh_secp256k1_asm = ["arrayref", "failure", "hex", "log", "rand", "bitcoinsecp256k1", "rand_chacha", "sha2/asm", "zeroize"]
-ecdsa_secp256k1 = ["amcl", "arrayref", "failure", "hex", "rand", "rand_chacha", "k256", "sha2/std", "zeroize"]
-ecdsa_secp256k1_native = ["arrayref", "failure", "hex", "log", "rand", "bitcoinsecp256k1", "rand_chacha", "sha2/std", "zeroize"]
-ecdsa_secp256k1_asm = ["arrayref", "failure", "hex", "log", "rand", "bitcoinsecp256k1", "rand_chacha", "sha2/asm", "zeroize"]
+ecdh_secp256k1 = ["amcl", "arrayref", "hex", "rand", "rand_chacha", "k256", "sha2/std", "zeroize"]
+ecdh_secp256k1_native = ["arrayref", "hex", "log", "rand", "bitcoinsecp256k1", "rand_chacha", "sha2/std", "zeroize"]
+ecdh_secp256k1_asm = ["arrayref", "hex", "log", "rand", "bitcoinsecp256k1", "rand_chacha", "sha2/asm", "zeroize"]
+ecdsa_secp256k1 = ["amcl", "arrayref", "hex", "rand", "rand_chacha", "k256", "sha2/std", "zeroize"]
+ecdsa_secp256k1_native = ["arrayref", "hex", "log", "rand", "bitcoinsecp256k1", "rand_chacha", "sha2/std", "zeroize"]
+ecdsa_secp256k1_asm = ["arrayref", "hex", "log", "rand", "bitcoinsecp256k1", "rand_chacha", "sha2/asm", "zeroize"]
 ed25519 = ["arrayref", "ed25519-dalek/std", "ed25519-dalek/u64_backend", "hex", "rand", "rand_chacha", "sha2/std", "zeroize"]
 ed25519_asm = ["arrayref", "ed25519-dalek/nightly", "ed25519-dalek/simd_backend", "hex", "rand", "rand_chacha", "sha2/asm", "zeroize"]
 encryption = ["aescbc", "aesgcm", "chacha20poly1305"]
 encryption_asm = ["aescbc_native", "aesgcm_native", "chacha20poly1305"]
-ffi = ["failure", "ffi-support", "logger", "serde", "serde_json"]
+ffi = ["ffi-support", "logger", "serde", "serde_json"]
 hashes = ["blake2/std", "sha2/std", "sha3"]
 hashes_asm = ["blake2/simd_asm", "sha2/asm", "sha3"]
 kex = ["ecdh_secp256k1", "x25519"]
@@ -98,12 +98,12 @@ kex_asm = ["ecdh_secp256k1_asm", "x25519_asm"]
 logger = ["env_logger", "log"]
 portable = ["clear_on_drop/no_cc", "encryption", "hashes", "kex", "serde", "signatures", "sharing"]
 portable_wasm = ["portable", "wasm"]
-sharing = ["failure", "glass_pumpkin", "int_traits", "lazy_static", "num-bigint", "num-integer", "num-traits", "log", "rand", "sha2/std"]
-sharing_native = ["failure", "int_traits", "lazy_static", "log", "openssl", "rand"]
+sharing = ["glass_pumpkin", "int_traits", "lazy_static", "num-bigint", "num-integer", "num-traits", "log", "rand", "sha2/std"]
+sharing_native = ["int_traits", "lazy_static", "log", "openssl", "rand"]
 signatures = ["cl", "ed25519", "ecdsa_secp256k1", "bls_bls12381", "bls_bn254"]
 signatures_native = ["cl_native", "ed25519", "ecdsa_secp256k1_native", "bls_bls12381", "bls_bn254"]
 signatures_asm = ["cl_native", "ed25519_asm", "ecdsa_secp256k1_asm", "bls_bls12381", "bls_bn254_asm"]
-wasm = ["console_error_panic_hook", "failure", "hex", "js-sys", "log", "rand/wasm-bindgen", "serde", "serde_json", "wasm-bindgen", "zeroize", "getrandom"]
+wasm = ["console_error_panic_hook", "hex", "js-sys", "log", "rand/wasm-bindgen", "serde", "serde_json", "wasm-bindgen", "zeroize"]
 x25519 = ["arrayref", "curve25519-dalek/std", "curve25519-dalek/u64_backend", "hex", "rand", "rand_chacha", "sha2/std", "x25519-dalek/std", "x25519-dalek/u64_backend", "zeroize"]
 x25519_asm = ["arrayref", "curve25519-dalek/nightly", "curve25519-dalek/avx2_backend", "hex", "rand", "rand_chacha", "sha2/asm", "x25519-dalek/nightly", "x25519-dalek/u64_backend", "zeroize"]
 
@@ -122,7 +122,6 @@ console_error_panic_hook = { version = "0.1.7", optional = true }
 curve25519-dalek = { version = "3.2", default-features = false, optional = true }
 ed25519-dalek = { version = "1.0", default-features = false, optional = true }
 env_logger = { version = "0.10", optional = true }
-failure = { version = "0.1.8", optional = true }
 ffi-support = { version = "0.4", optional = true }
 glass_pumpkin = { version = "1.5", optional = true }
 hex = { version = "0.4.3", optional = true }
@@ -135,7 +134,7 @@ log = { version = "0.4.17", optional = true }
 num-bigint = { version = "0.4", features = ["rand"], optional = true }
 num-integer = { version = "0.1.45", optional = true }
 num-traits = { version = "0.2.15", optional = true }
-openssl = { version = "0.10", optional = true }
+openssl = { version = "0.10.48", optional = true }
 # TODO: Find out if the wasm-bindgen feature can be made dependent on our own wasm feature
 rand = { version = "0.7", features = ["wasm-bindgen"], optional = true }
 getrandom = { version = "0.2", features = ["js"], optional = true }
@@ -151,6 +150,7 @@ subtle = { version = "2.4", optional = true }
 wasm-bindgen = { version = "0.2", optional = true, features = ["serde-serialize"] }
 x25519-dalek = { version = "1.2.1", optional = true, default-features = false, git = "https://github.com/appetrosyan/x25519-dalek" }
 zeroize = { version = "1.5", features = ["zeroize_derive"], optional =  true }
+thiserror = "1.0.40"
 
 [dev-dependencies]
 bytebuffer-rs = "2.0.1"


### PR DESCRIPTION
One of the main problems for `cargo audit` is the outdated and unmaintained `failure` library. 

We are slowly replacing the functionality with the `thiserror` crate. 